### PR TITLE
Fix WriteResult#getN() using a wrapper

### DIFF
--- a/src/main/java/com/mongodb/FongoWriteResult.java
+++ b/src/main/java/com/mongodb/FongoWriteResult.java
@@ -1,0 +1,23 @@
+package com.mongodb;
+
+public class FongoWriteResult extends WriteResult {
+    /**
+     * Number of documents affected by a write operation.
+     */
+    private int n;
+
+    FongoWriteResult(CommandResult o, WriteConcern concern, int n) {
+        super(o, concern);
+        this.n = n;
+    }
+
+    FongoWriteResult(DB db, DBPort p, WriteConcern concern, int n) {
+        super(db, p, concern);
+        this.n = n;
+    }
+
+    @Override
+    public int getN() {
+        return n;
+    }
+}

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -23,6 +23,7 @@ import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
+import com.mongodb.WriteResult;
 
 public class FongoTest {
 
@@ -63,7 +64,6 @@ public class FongoTest {
     collection.insert(new BasicDBObject("n", 2));
     assertEquals(2, collection.count(new BasicDBObject("n", 2)));
   }
-  
   
   @Test
   public void testInsertIncrementsCount() {
@@ -482,7 +482,6 @@ public class FongoTest {
     
   }
   
-  
   @Test
   public void testDistinctQuery() {
     DBCollection collection = newCollection();
@@ -557,7 +556,33 @@ public class FongoTest {
             new BasicDBObject("_id", 1).append("a", new BasicDBObject("b", 1))
         ),results);
   }
+
+  @Test
+  public void testInsertReturnModifiedDocumentCount() {
+    DBCollection collection = newCollection();
+    WriteResult result = collection.insert(new BasicDBObject("_id", new BasicDBObject("n", 1)));
+    assertEquals(1, result.getN());
+  }
   
+  @Test
+  public void testUpdateWithIdInMultiReturnModifiedDocumentCount() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1),new BasicDBObject("_id", 2));
+    WriteResult result = collection.update(new BasicDBObject("_id", new BasicDBObject("$in", Arrays.asList(1,2))), 
+        new BasicDBObject("$set", new BasicDBObject("n", 1)), false, true);
+    assertEquals(2, result.getN());
+  }
+  
+  @Test
+  public void testUpdatetWithObjectIdReturnModifiedDocumentCount() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", new BasicDBObject("n", 1)));
+    DBObject query = new BasicDBObject("_id", new BasicDBObject("n", 1));
+    DBObject update = new BasicDBObject("$set", new BasicDBObject("a", 1));
+    WriteResult result = collection.update(query, update, false, false);
+    assertEquals(1, result.getN());
+  }
+
   @Test
   public void testToString() {
     new Fongo("test").getMongo().toString();


### PR DESCRIPTION
In this patch I've added a com.mongodb.WriteResult wrapper called FongoWriteResult that stores the number of documents that have been modified in a write (update, insert, remove) operation.

This way the calls to WriteResult#getN() return the right value instead of returning 0 or throwing an exception.

Some unit tests have been implemented.
