### PR TITLE
__find() updates

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -346,7 +346,7 @@ public class FongoDBCollection extends DBCollection {
       LOG.debug("found results " + results);
     }
     if (results.size() == 0){
-      return null;
+      return new ArrayList<DBObject>().iterator();
     } else {
       return results.iterator();      
     }

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -352,6 +352,11 @@ public class FongoDBCollection extends DBCollection {
     }
   }
 
+  @Override
+  Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options, ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
+    return __find(ref, fields, numToSkip, batchSize, limit, options, readPref, decoder);
+  }
+
   public Collection<DBObject> sortObjects(final DBObject orderby) {
     Collection<DBObject> objectsToSearch = objects.values();
     if (orderby != null) {

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -35,6 +35,8 @@ public class FongoDBCollection extends DBCollection {
   private final UpdateEngine updateEngine;
   private final boolean nonIdCollection;
   private final ObjectComparator objectComparator;
+
+  private final Iterator<DBObject> emptyIterator = new ArrayList<DBObject>().iterator();
   
   public FongoDBCollection(FongoDB db, String name) {
     super(db, name);
@@ -346,7 +348,7 @@ public class FongoDBCollection extends DBCollection {
       LOG.debug("found results " + results);
     }
     if (results.size() == 0){
-      return new ArrayList<DBObject>().iterator();
+      return emptyIterator;
     } else {
       return results.iterator();      
     }


### PR DESCRIPTION
[The mongo driver does not hadle `null` as a return value from `__find()`](https://github.com/mongodb/mongo-java-driver/blob/master/src/main/com/mongodb/DBCollection.java#L345). I changed `__find()` to return an empty iterator instead. 

Also, [`DBCollection` requires the implementation of a `__find(..., DBEncoder)` method](https://github.com/mongodb/mongo-java-driver/blob/master/src/main/com/mongodb/DBCollection.java#L275). Added that as well, to simply call the `__find()` without `DBEncoder` method.
