### PR TITLE
Fixing _id generation cases

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -90,7 +90,7 @@ public class FongoDBCollection extends DBCollection {
   }
 
   public Object putIdIfNotPresent(DBObject obj) {
-    if (!obj.containsField(ID_KEY)) {
+    if (!obj.containsField(ID_KEY) || obj.get(ID_KEY) == null) {
       ObjectId id = new ObjectId();
       if (!nonIdCollection){
         obj.put(ID_KEY, id);

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -582,6 +582,27 @@ public class FongoTest {
     assertEquals(1, result.getN());
   }
 
+  /**
+   * Test that ObjectId is getting generated even if _id is present in
+   * DBObject but it's value is null
+   *
+   * @throws Exception
+   */
+  @Test
+  public void testIdGenerated() throws Exception {
+    DBObject toSave = new BasicDBObject();
+    toSave.put("_id", null);
+    toSave.put("name", "test");
+    Fongo fongo = newFongo();
+    DB fongoDB = fongo.getDB("testDB");
+    DBCollection collection = fongoDB.getCollection("testCollection");
+    collection.save(toSave);
+    DBObject result = collection.findOne(new BasicDBObject("name", "test"));
+    //default index in mongoDB
+    final String ID_KEY = "_id";
+    assertNotNull("Expected _id to be generated" + result.get(ID_KEY));
+  }
+
   @Test
   public void testToString() {
     new Fongo("test").getMongo().toString();


### PR DESCRIPTION
Small change to fix _id index field generation while using Fongo with Spring-Data-Mongodb.

The problem is that Spring-Data-MongoDB filling DBObject with _id key and null value if integrated with fongo.
<spring.data.mongodb.version>1.0.3.RELEASE</spring.data.mongodb.version>
<dependency>
                <groupId>org.springframework.data</groupId>
                <artifactId>spring-data-mongodb</artifactId>
                <version>${spring.data.mongodb.version}</version>
</dependency>

Test case is also in code. 
