### PR TITLE
Distinct for key should return distinct values for that key, not objects containing those distinct values.

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -14,7 +14,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -474,10 +473,9 @@ public class FongoDBCollection extends DBCollection {
   public synchronized List distinct(String key, DBObject query) {
     List<Object> results = new ArrayList<Object>();
     Filter filter = expressionParser.buildFilter(query);
-    Set<Object> seen = new HashSet<Object>();
     for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext();) {
       DBObject value = iter.next();
-      if (filter.apply(value) && seen.add(value.get(key))){
+      if (filter.apply(value) && !results.contains(value.get(key))){
         results.add(value.get(key));
       }
     }

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1,5 +1,14 @@
 package com.mongodb;
 
+import com.foursquare.fongo.FongoException;
+import com.foursquare.fongo.impl.ExpressionParser;
+import com.foursquare.fongo.impl.Filter;
+import com.foursquare.fongo.impl.UpdateEngine;
+import com.foursquare.fongo.impl.Util;
+import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -11,16 +20,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
-import org.bson.types.ObjectId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.foursquare.fongo.FongoException;
-import com.foursquare.fongo.impl.ExpressionParser;
-import com.foursquare.fongo.impl.Filter;
-import com.foursquare.fongo.impl.UpdateEngine;
-import com.foursquare.fongo.impl.Util;
 
 /**
  * fongo override of com.mongodb.DBCollection
@@ -472,14 +471,14 @@ public class FongoDBCollection extends DBCollection {
   }
   
   @Override
-  public synchronized List<DBObject> distinct(String key, DBObject query) {
-    List<DBObject> results = new ArrayList<DBObject>();
+  public synchronized List distinct(String key, DBObject query) {
+    List<Object> results = new ArrayList<Object>();
     Filter filter = expressionParser.buildFilter(query);
     Set<Object> seen = new HashSet<Object>();
     for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext();) {
       DBObject value = iter.next();
       if (filter.apply(value) && seen.add(value.get(key))){
-        results.add(value);
+        results.add(value.get(key));
       }
     }
     return results;

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -1,19 +1,5 @@
 package com.foursquare.fongo;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.foursquare.fongo.impl.Util;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -26,6 +12,19 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FongoTest {
 
@@ -490,11 +489,7 @@ public class FongoTest {
     collection.insert(new BasicDBObject("n", 3).append("_id", 3));
     collection.insert(new BasicDBObject("n", 1).append("_id", 4));
     collection.insert(new BasicDBObject("n", 1).append("_id", 5));
-    assertEquals(Arrays.asList(
-        new BasicDBObject("n", 1).append("_id", 1), 
-        new BasicDBObject("n", 2).append("_id", 2), 
-        new BasicDBObject("n", 3).append("_id", 3)
-    ), collection.distinct("n"));
+    assertEquals(Arrays.asList(1, 2, 3), collection.distinct("n"));
   }
   
   @Test
@@ -521,7 +516,8 @@ public class FongoTest {
     collection.insert(new BasicDBObject("_id", 1));
     collection.insert(new BasicDBObject("_id", 1), WriteConcern.SAFE);
   }
-  
+
+  @Test
   public void testInsertDuplicateIgnored(){
     DBCollection collection = newCollection();
     collection.insert(new BasicDBObject("_id", 1));


### PR DESCRIPTION
The current test for `DBCollection.distinct(String key)` does not represent the same contract as the Mongo Java driver equivalent:

``` java
@Test
  public void testDistinctQuery() {
    DBCollection collection = newCollection();
    collection.insert(new BasicDBObject("n", 1).append("_id", 1));
    collection.insert(new BasicDBObject("n", 2).append("_id", 2));
    collection.insert(new BasicDBObject("n", 3).append("_id", 3));
    collection.insert(new BasicDBObject("n", 1).append("_id", 4));
    collection.insert(new BasicDBObject("n", 1).append("_id", 5));
    assertEquals(Arrays.asList(
        new BasicDBObject("n", 1).append("_id", 1), 
        new BasicDBObject("n", 2).append("_id", 2), 
        new BasicDBObject("n", 3).append("_id", 3)
    ), collection.distinct("n"));
  }
```

Instead of returning one of the objects containing each of the distinct values of 'n', just the values of 'n' should be returned in a list:

``` java
@Test
  public void testDistinctQuery() {
    DBCollection collection = newCollection();
    collection.insert(new BasicDBObject("n", 1).append("_id", 1));
    collection.insert(new BasicDBObject("n", 2).append("_id", 2));
    collection.insert(new BasicDBObject("n", 3).append("_id", 3));
    collection.insert(new BasicDBObject("n", 1).append("_id", 4));
    collection.insert(new BasicDBObject("n", 1).append("_id", 5));
    assertEquals(Arrays.asList(1, 2, 3), collection.distinct("n"));
  }
```

The attached pull request redefines the test as such and makes the relevant fix to `FongoDBCollection`.
