### PR TITLE
getLastError should contain updatedExisting key with boolean value on update.

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1,5 +1,14 @@
 package com.mongodb;
 
+import com.foursquare.fongo.FongoException;
+import com.foursquare.fongo.impl.ExpressionParser;
+import com.foursquare.fongo.impl.Filter;
+import com.foursquare.fongo.impl.UpdateEngine;
+import com.foursquare.fongo.impl.Util;
+import org.bson.types.ObjectId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -12,25 +21,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.bson.types.ObjectId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.foursquare.fongo.FongoException;
-import com.foursquare.fongo.impl.ExpressionParser;
-import com.foursquare.fongo.impl.Filter;
-import com.foursquare.fongo.impl.UpdateEngine;
-import com.foursquare.fongo.impl.Util;
-
 /**
  * fongo override of com.mongodb.DBCollection
  * you shouldn't need to use this class directly
- * 
+ *
  * @author jon
  */
 public class FongoDBCollection extends DBCollection {
   final static Logger LOG = LoggerFactory.getLogger(FongoDBCollection.class);
-  
+
   final static String ID_KEY = "_id";
   private final FongoDB fongoDb;
   // LinkedHashMap maintains insertion order
@@ -40,7 +39,7 @@ public class FongoDBCollection extends DBCollection {
   private final UpdateEngine updateEngine;
   private final boolean nonIdCollection;
   private final ObjectComparator objectComparator;
-  
+
   public FongoDBCollection(FongoDB db, String name) {
     super(db, name);
     this.fongoDb = db;
@@ -49,25 +48,25 @@ public class FongoDBCollection extends DBCollection {
     this.updateEngine = new UpdateEngine();
     this.objectComparator = new ObjectComparator();
   }
-  
+
   class ObjectComparator implements Comparator {
     @Override
     public int compare(Object o1, Object o2) {
       return expressionParser.compareObjects(o1, o2);
     }
   }
-  
+
   private CommandResult updateResult(int updateCount) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
     return result;
   }
-  
+
   @Override
   public synchronized WriteResult insert(DBObject[] arr, WriteConcern concern, DBEncoder encoder) throws MongoException {
     return insert(Arrays.asList(arr), concern, encoder);
   }
-  
+
   public WriteResult insert(List<DBObject> toInsert, WriteConcern concern, DBEncoder encoder) {
     for (DBObject obj : toInsert) {
       if (LOG.isDebugEnabled()) {
@@ -78,17 +77,17 @@ public class FongoDBCollection extends DBCollection {
 
       if (objects.containsKey(id)) {
         if (enforceDuplicates(concern)) {
-          throw new MongoException.DuplicateKey(0, "Attempting to insert duplicate _id: " + id);          
+          throw new MongoException.DuplicateKey(0, "Attempting to insert duplicate _id: " + id);
         } else {
           // TODO(jon) log          
         }
       } else {
-        putSizeCheck(id, obj);        
+        putSizeCheck(id, obj);
       }
     }
     return new WriteResult(updateResult(toInsert.size()), concern);
   }
-  
+
   boolean enforceDuplicates(WriteConcern concern) {
     return !(WriteConcern.NONE.equals(concern) || WriteConcern.NORMAL.equals(concern));
   }
@@ -111,7 +110,7 @@ public class FongoDBCollection extends DBCollection {
     }
     objects.put(id, obj);
   }
-  
+
   public DBObject filterLists(DBObject dbo){
     if (dbo == null) {
       return null;
@@ -163,15 +162,17 @@ public class FongoDBCollection extends DBCollection {
       throw new MongoException.DuplicateKey(0, "can not change _id of a document " + ID_KEY);
     }
     filterLists(o);
-    
+
     int updatedDocuments = 0;
-    
+
     if (idOnlyUpdate && isNotUpdateCommand(o)) {
       if (!o.containsField(ID_KEY)) {
         o.put(ID_KEY, q.get(ID_KEY));
       }
-      fInsert(o);
-      updatedDocuments++;
+      if (objects.containsKey(q.get(ID_KEY))) {
+        fInsert(o);
+        updatedDocuments++;
+      }
     } else {
       filterLists(q);
       List idsIn = idsIn(q);
@@ -198,17 +199,14 @@ public class FongoDBCollection extends DBCollection {
           }
         }
       }
-      if (updatedDocuments == 0 && upsert){
-        BasicDBObject newObject = createUpsertObject(q);
-        fInsert(updateEngine.doUpdate(newObject, o, q));
-      }
+    }
+    if (updatedDocuments == 0 && upsert) {
+      BasicDBObject newObject = createUpsertObject(q);
+      fInsert(updateEngine.doUpdate(newObject, o, q));
     }
     return new WriteResult(updateResult(updatedDocuments), concern);
   }
-  
 
-  
-  
   public List idsIn(DBObject query) {
     Object idValue = query.get(ID_KEY);
     if (idValue == null || query.keySet().size() > 1) {
@@ -216,7 +214,7 @@ public class FongoDBCollection extends DBCollection {
     } else if (idValue instanceof DBObject ){
       DBObject idDbObject = (DBObject)idValue;
       List inList = (List)idDbObject.get(ExpressionParser.IN);
-      
+
       // I think sorting the inputed keys is a rough
       // approximation of how mongo creates the bounds for walking
       // the index.  It has the desired affect of returning results
@@ -230,14 +228,14 @@ public class FongoDBCollection extends DBCollection {
       if (!isNotUpdateCommand(idValue)){
         return Collections.emptyList();
       }
-    } 
+    }
     return Collections.singletonList(idValue);
   }
 
   protected  BasicDBObject createUpsertObject(DBObject q) {
     BasicDBObject newObject = new BasicDBObject();
     List idsIn = idsIn(q);
-    
+
     if (!idsIn.isEmpty()){
       newObject.put(ID_KEY, idsIn.get(0));
     } else {
@@ -279,7 +277,7 @@ public class FongoDBCollection extends DBCollection {
     int updatedDocuments = 0;
     if (!idList.isEmpty()) {
       for (Object id : idList){
-        objects.remove(id);        
+        objects.remove(id);
       }
       updatedDocuments = idList.size();
     } else {
@@ -322,10 +320,10 @@ public class FongoDBCollection extends DBCollection {
   @Override
   Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options,
       ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
-    
+
     return __find(ref, fields, numToSkip, batchSize, limit, options, readPref, decoder);
   }
-  
+
   /**
    * note: decoder, readPref, options are ignored
    */
@@ -345,7 +343,7 @@ public class FongoDBCollection extends DBCollection {
       for (Object id : idList){
         DBObject result = objects.get(id);
         if (result != null){
-          results.add(result);          
+          results.add(result);
         }
       }
     } else {
@@ -354,7 +352,7 @@ public class FongoDBCollection extends DBCollection {
         orderby = (DBObject)ref.get("orderby");
         ref = (DBObject)ref.get("query");
       }
-      
+
       Filter filter = expressionParser.buildFilter(ref);
       int foundCount = 0;
       int upperLimit = Integer.MAX_VALUE;
@@ -396,7 +394,7 @@ public class FongoDBCollection extends DBCollection {
 
               List<Object> o1list = expressionParser.getEmbeddedValues(path, o1);
               List<Object> o2list = expressionParser.getEmbeddedValues(path, o2);
-              
+
               int compareValue = expressionParser.compareLists(o1list, o2list) * sortDirection;
               if (compareValue != 0){
                 return compareValue;
@@ -413,7 +411,7 @@ public class FongoDBCollection extends DBCollection {
     return objectsToSearch;
   }
 
-  
+
   @Override
   public synchronized long getCount(DBObject query, DBObject fields, long limit, long skip ) {
     Filter filter = expressionParser.buildFilter(query);
@@ -470,7 +468,7 @@ public class FongoDBCollection extends DBCollection {
       return beforeObject;
     }
   }
-  
+
   @Override
   public synchronized List<DBObject> distinct(String key, DBObject query) {
     List<DBObject> results = new ArrayList<DBObject>();
@@ -484,12 +482,12 @@ public class FongoDBCollection extends DBCollection {
     }
     return results;
   }
-  
+
   @Override
   public void dropIndexes(String name) throws MongoException {
     // do nothing
   }
-  
+
   @Override
   public void drop() {
     objects.clear();

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -59,6 +59,7 @@ public class FongoDBCollection extends DBCollection {
   private CommandResult updateResult(int updateCount) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
+    result.put("updatedExisting", !(updateCount == 0));
     return result;
   }
 

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -1,19 +1,5 @@
 package com.foursquare.fongo;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.List;
-
-import org.junit.Test;
-
 import com.foursquare.fongo.impl.Util;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
@@ -26,6 +12,19 @@ import com.mongodb.DBObject;
 import com.mongodb.MongoException;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class FongoTest {
 
@@ -321,6 +320,13 @@ public class FongoTest {
         new BasicDBObject("_id", 2).append("n", 1)
     ), results);
     
+  }
+
+  @Test
+  public void testUpdateWithUnknownId() throws Exception {
+    DBCollection collection = newCollection();
+    collection.update(new BasicDBObject("_id", 1), new BasicDBObject("a", 5), false, false);
+    assertEquals(null, collection.findOne());
   }
   
   @Test

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -328,6 +328,42 @@ public class FongoTest {
     collection.update(new BasicDBObject("_id", 1), new BasicDBObject("a", 5), false, false);
     assertEquals(null, collection.findOne());
   }
+
+  @Test
+  public void testLastErrorUpdatedExistingTrueOnUpdate() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("b", 10));
+    WriteResult result = collection.update(new BasicDBObject("_id", 1), new BasicDBObject("a", 5));
+    CommandResult lastError = result.getLastError();
+    assertEquals(true, lastError.get("updatedExisting"));
+  }
+
+  @Test
+  public void testLastErrorUpdatedExistingTrueOnUpdateMulti() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("b", 10));
+    collection.insert(new BasicDBObject("_id", 2).append("b", 10));
+    WriteResult result = collection.update(new BasicDBObject("b", 10), new BasicDBObject("$set", new BasicDBObject("b", 20)));
+    CommandResult lastError = result.getLastError();
+    assertEquals(true, lastError.get("updatedExisting"));
+  }
+
+  @Test
+  public void testLastErrorUpdatedExistingFalseOnUpsert() throws Exception {
+    DBCollection collection = newCollection();
+    WriteResult result = collection.update(new BasicDBObject("_id", 2), new BasicDBObject("a", 5), true, false);
+    CommandResult lastError = result.getLastError();
+    assertEquals(false, lastError.get("updatedExisting"));
+  }
+
+  @Test
+  public void testLastErrorUpdatedExistingFalseOnNoQueryMatches() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("b", 10));
+    WriteResult result = collection.update(new BasicDBObject("_id", 2), new BasicDBObject("a", 5));
+    CommandResult lastError = result.getLastError();
+    assertEquals(false, lastError.get("updatedExisting"));
+  }
   
   @Test
   public void testCompoundDateIdUpserts(){


### PR DESCRIPTION
Whilst there isn't a method exposed for it, the `CommandResult` returned through `WriteResult#getLastError()` should contain a key-value pair for key "updatedExisting" which determines whether any existing documents were updated.

This pull request makes that key available and adds tests for all relevant cases.
