### PR TITLE
Allow Map instances to be passed in query objects since this is permitted in the Java driver.

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
+++ b/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
@@ -1,19 +1,20 @@
 package com.foursquare.fongo.impl;
 
+import com.foursquare.fongo.FongoException;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.DBObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.foursquare.fongo.FongoException;
-import com.mongodb.BasicDBList;
-import com.mongodb.DBObject;
 
 public class ExpressionParser {
   final static Logger LOG = LoggerFactory.getLogger(ExpressionParser.class);
@@ -309,8 +310,7 @@ public class ExpressionParser {
   }
   
 
-  private Filter buildExpressionFilter(final List<String> path, final Object expression) {
-
+  private Filter buildExpressionFilter(final List<String> path, Object expression) {
     if (path.get(0) == OR) {
       List<DBObject> queryList = typecast(path + " operator", expression, List.class);
       OrFilter orFilter = new OrFilter();
@@ -318,8 +318,8 @@ public class ExpressionParser {
         orFilter.addFilter(buildFilter(query));
       }
       return orFilter;
-    } else if (expression instanceof DBObject) {
-      DBObject ref = (DBObject) expression;
+    } else if (expression instanceof DBObject || expression instanceof Map) {
+      DBObject ref = expression instanceof DBObject ? (DBObject) expression : new BasicDBObject((Map) expression);
       Object notExpression = ref.get(NOT);
       if (notExpression != null) {
         return new NotFilter(buildExpressionFilter(path, notExpression));

--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -1,24 +1,21 @@
 package com.foursquare.fongo.impl;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import com.mongodb.BasicDBList;
+import com.mongodb.BasicDBObject;
+import com.mongodb.BasicDBObjectBuilder;
+import com.mongodb.DBObject;
+import org.bson.types.ObjectId;
+import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.regex.Pattern;
 
-import org.bson.types.ObjectId;
-import org.junit.Test;
-
-import com.foursquare.fongo.impl.ExpressionParser;
-import com.foursquare.fongo.impl.Filter;
-import com.mongodb.BasicDBList;
-import com.mongodb.BasicDBObject;
-import com.mongodb.BasicDBObjectBuilder;
-import com.mongodb.DBCollection;
-import com.mongodb.DBObject;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 
 public class ExpressionParserTest {
@@ -593,6 +590,21 @@ public class ExpressionParserTest {
         rec1,
         rec2
     ), results);
+  }
+
+  @Test
+  public void testOperatorInMap() throws Exception {
+    HashMap<String, Object> operatorMap = new HashMap<String, Object>();
+    operatorMap.put("$in", asList(1, 2, 3));
+    BasicDBObject query = new BasicDBObject("a", operatorMap);
+    BasicDBObject rec1 = new BasicDBObject("_id", 1).append("a", 1).append("b", "5").append("c", 1);
+    BasicDBObject rec2 = new BasicDBObject("_id", 2).append("a", 4).append("b", "8").append("c", 1);
+    List<DBObject> results = doFilter(
+        query,
+        rec1,
+        rec2
+    );
+    assertEquals(Arrays.<DBObject>asList(rec1), results);
   }
 
   private void assertQuery(BasicDBObject query, List<DBObject> expected) {


### PR DESCRIPTION
The Java Driver supports a query object of the following form:

``` java
HashMap<String, Object> operatorMap = new HashMap<String, Object>();
operatorMap.put("$in", asList(1, 2, 3));
BasicDBObject query = new BasicDBObject("a", operatorMap);
```

with a value that is a `Map` containing further expressions and operators.

It is important to me that this is supported since this behaviour is leveraged by morphia when creating queries.

This pull request extends `ExpressionParser` to allow this case and adds a test to demonstrate usage.
