### PR TITLE
Add create collection support

### DIFF
--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -99,6 +99,10 @@ public class FongoDB extends DB {
     } else if (cmd.containsField("drop")) {
       this.collMap.remove(cmd.get("drop").toString());
       return okResult();
+    } else if(cmd.containsField("create")) {
+        String collectionName = (String) cmd.get("create");
+        doGetCollection(collectionName);
+        return okResult();
     }
     CommandResult errorResult = new CommandResult(fongo.getServerAddress());
     errorResult.put("err", "undefined command: " + cmd);

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -49,6 +49,14 @@ public class FongoTest {
     assertEquals(new HashSet<String>(Arrays.asList("coll")), db.getCollectionNames());
   }
   
+  @Test
+  public void testCreateCollection() {
+      Fongo fongo = newFongo();
+      DB db = fongo.getDB("db");
+      db.createCollection("coll", null);
+      assertEquals(Collections.singleton("coll"), db.getCollectionNames());
+  }
+
   @Test 
   public void testCountCommand() {
     DBCollection collection = newCollection();


### PR DESCRIPTION
Prior to this fix `db.createCollection()` was ending on an exception in the driver. This fix adds create collection support implemented on top of the method `doGetCollection`.
