### PR TITLE
Fongo failed with 'ok' should never be null if DBCursor.count() was used

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 .cache
 .settings
 test-output
+bin

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -66,6 +66,7 @@ public class FongoDBCollection extends DBCollection {
     return insert(Arrays.asList(arr), concern, encoder);
   }
   
+  @Override
   public WriteResult insert(List<DBObject> toInsert, WriteConcern concern, DBEncoder encoder) {
     for (DBObject obj : toInsert) {
       if (LOG.isDebugEnabled()) {
@@ -432,7 +433,14 @@ public class FongoDBCollection extends DBCollection {
     }
     return count;
   }
+  
+  @Override
+  public synchronized long getCount(DBObject query, DBObject fields, ReadPreference readPrefs){
+    //as we're in memory we don't need to worry about readPrefs
+    return getCount(query, fields, 0, 0);
+  }
 
+  @Override
   public synchronized DBObject findAndModify(DBObject query, DBObject fields, DBObject sort, boolean remove, DBObject update, boolean returnNew, boolean upsert) {
     filterLists(query);
     filterLists(update);

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -10,6 +10,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.MongoException;
+import com.mongodb.QueryBuilder;
 import com.mongodb.WriteConcern;
 import com.mongodb.WriteResult;
 import org.junit.Test;
@@ -70,6 +71,15 @@ public class FongoTest {
     collection.insert(new BasicDBObject("n", 2));
     collection.insert(new BasicDBObject("n", 2));
     assertEquals(2, collection.count(new BasicDBObject("n", 2)));
+  }
+  
+  @Test
+  public void testCountOnCursor() {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("n", 1));
+    collection.insert(new BasicDBObject("n", 2));
+    collection.insert(new BasicDBObject("n", 2));
+    assertEquals(3,collection.find(QueryBuilder.start("n").exists(true).get()).count());
   }
   
   @Test


### PR DESCRIPTION
I guess with the change to the new MongoClient API a new count method was introduced: getCount(DBObject query, DBObject fields, ReadPreference readPrefs)

But fongo doesn't override that method, which leads to:

java.lang.IllegalArgumentException: 'ok' should never be null...
    at com.mongodb.CommandResult.ok(CommandResult.java:48)
    at com.mongodb.DBCollection.getCount(DBCollection.java:985)
    at com.mongodb.DBCollection.getCount(DBCollection.java:942)
    at com.mongodb.DBCursor.count(DBCursor.java:586)
    at com.foursquare.fongo.FongoTest.testCountOnCursor(FongoTest.java:82)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:601)
    at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:45)
    at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:15)
    at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:42)
    at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:20)
    at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:263)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:68)
    at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:47)
    at org.junit.runners.ParentRunner$3.run(ParentRunner.java:231)
    at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:60)
    at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:229)
    at org.junit.runners.ParentRunner.access$000(ParentRunner.java:50)
    at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:222)
    at org.junit.runners.ParentRunner.run(ParentRunner.java:300)
    at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:50)
    at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:467)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:683)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:390)
    at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:197)

It's working again once the method is overriden correctly.
