### PR TITLE
Fix for issue #19 dropDatabase with 2 collections should not throw ConcurrentModificationException

### DIFF
--- a/src/main/java/com/mongodb/FongoDB.java
+++ b/src/main/java/com/mongodb/FongoDB.java
@@ -1,5 +1,6 @@
 package com.mongodb;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,7 +75,7 @@ public class FongoDB extends DB {
   @Override
   public void dropDatabase() throws MongoException {
     this.fongo.dropDatabase(this.getName());
-    for (FongoDBCollection c : collMap.values()) {
+    for (FongoDBCollection c : new ArrayList<FongoDBCollection>(collMap.values())) {
       c.drop();
     }
   }

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -684,6 +684,18 @@ public class FongoTest {
   }
 
   @Test
+  public void testDropDatabaseFromFongoWithMultipleCollectionsDropsBothCollections() throws Exception {
+    Fongo fongo = newFongo();
+    DB db = fongo.getDB("db");
+    DBCollection collection1 = db.getCollection("coll1");
+    DBCollection collection2= db.getCollection("coll2");
+    db.dropDatabase();
+    assertFalse("Collection 1 shouldn't exist in DB", db.collectionExists(collection1.getName()));
+    assertFalse("Collection 2 shouldn't exist in DB", db.collectionExists(collection2.getName()));
+    assertFalse("DB shouldn't exist in fongo", fongo.getDatabaseNames().contains("db"));
+  }
+
+  @Test
   public void testToString() {
     new Fongo("test").getMongo().toString();
   }


### PR DESCRIPTION
Fixed issue #19 by first copying the collection set to avoid iterating and deleting from the same iterator.

Also added a test for this.
