### PR TITLE
Add support for top-level $and queries

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
+++ b/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
@@ -32,6 +32,7 @@ public class ExpressionParser {
   public final static String SIZE = "$size";
   public final static String NOT = "$not";
   public final static String OR = "$or";
+  public final static String AND = "$and";
   public final static String REGEX = "$regex";
   public final static String REGEX_OPTIONS = "$options";
 
@@ -318,6 +319,13 @@ public class ExpressionParser {
         orFilter.addFilter(buildFilter(query));
       }
       return orFilter;
+    } else if (AND.equals(path.get(0))) {
+      List<DBObject> queryList = typecast(path + " operator", expression, List.class);
+      AndFilter andFilter = new AndFilter();
+      for (DBObject query : queryList) {
+        andFilter.addFilter(buildFilter(query));
+      }
+      return andFilter;
     } else if (expression instanceof DBObject || expression instanceof Map) {
       DBObject ref = expression instanceof DBObject ? (DBObject) expression : new BasicDBObject((Map) expression);
       

--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -7,6 +7,7 @@ import com.mongodb.DBObject;
 import org.bson.types.ObjectId;
 import org.junit.Test;
 
+import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -33,6 +34,24 @@ public class ExpressionParserTest {
     assertEquals(Arrays.<DBObject>asList(
         new BasicDBObject("a", asList(1,3)).append("n", "j"),
         new BasicDBObject("a", 3).append("n", "j")
+    ), results);
+  }
+  
+  @Test
+  public void topLevelAndFilter() {
+    DBObject query = new BasicDBObject("$and", Arrays.asList(new BasicDBObject("a", 3), new BasicDBObject("b", 4)));
+    
+    List<DBObject> results = doFilter(
+        query,
+        new BasicDBObject("a", 3).append("b", 4),
+        new BasicDBObject("a", 3).append("b", 5),
+        new BasicDBObject("b", 4),
+        new BasicDBObject("a", 3),
+        new BasicDBObject("a", 5).append("b", 4)
+    );
+    
+    assertEquals(Arrays.<DBObject>asList(
+        new BasicDBObject("a", 3).append("b", 4)
     ), results);
   }
   


### PR DESCRIPTION
Support queries like '{$and: [{a: 1}, {b: 2}]}' which are valid MongoDB queries.
