### PR TITLE
Add regex support to $all query

### DIFF
--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -38,6 +38,26 @@ public class ExpressionParserTest {
   }
   
   @Test
+  public void nestedAllRegexFilter() {
+    DBObject query = new BasicDBObject("_keywords", new BasicDBObject("$all", Arrays.asList("john", Pattern.compile("^doe"))));
+    
+    List<DBObject> results = doFilter(
+        query,
+        new BasicDBObject("_keywords", Arrays.asList("john", "more")),
+        new BasicDBObject("_keywords", Arrays.asList("tim", "norton")),
+        new BasicDBObject("_keywords", Arrays.asList("john", new BasicDBObject("doe", ""))),
+        new BasicDBObject("_keywords", Arrays.asList("john", "doeson")),
+        new BasicDBObject("_keywords", Arrays.asList("john", "don")),
+        new BasicDBObject("_keywords", Arrays.asList("john", "doe"))
+    );
+    
+    assertEquals(Arrays.<DBObject>asList(
+        new BasicDBObject("_keywords", Arrays.asList("john", "doeson")),
+        new BasicDBObject("_keywords", Arrays.asList("john", "doe"))
+    ), results);
+  }
+  
+  @Test
   public void topLevelAndFilter() {
     DBObject query = new BasicDBObject("$and", Arrays.asList(new BasicDBObject("a", 3), new BasicDBObject("b", 4)));
     


### PR DESCRIPTION
Regex is allowed inside of `$all` operation, so

```
db.test.insert({name: 'john johnson', keywords: ['john', 'johnson']});
db.test.find({keywords: {$all: ['john', /^jo/]}});
```

should return one result.
