### PR TITLE
findAndModify() returns nested properties of the updated object instead of the original object

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/Util.java
+++ b/src/main/java/com/foursquare/fongo/impl/Util.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import com.mongodb.BasicDBList;
+import com.mongodb.*;
 
 public class Util {
   public static <T> BasicDBList list(T ... ts){
@@ -33,5 +33,21 @@ public class Util {
       path.add(key);
       return path;
     }
+  }
+
+  public static <T extends DBObject> T clone(T source) {
+    if (source instanceof BasicDBObject) {
+      @SuppressWarnings("unchecked")
+      T clone = (T) ((BasicDBObject) source).copy();
+      return clone;
+    }
+    
+    if (source instanceof BasicDBList) {
+      @SuppressWarnings("unchecked")
+      T clone = (T) ((BasicDBList) source).copy();
+      return clone;
+    }
+    
+    throw new IllegalArgumentException("Don't know how to clone: " + source);
   }
 }

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1,5 +1,7 @@
 package com.mongodb;
 
+import ch.qos.logback.classic.db.names.SimpleDBNameResolver;
+
 import com.foursquare.fongo.FongoException;
 import com.foursquare.fongo.impl.ExpressionParser;
 import com.foursquare.fongo.impl.Filter;
@@ -470,8 +472,7 @@ public class FongoDBCollection extends DBCollection {
       if (filter.apply(dbo)) {
         beforeObject = dbo;
         if (!remove) {
-          afterObject = new BasicDBObject();
-          afterObject.putAll(beforeObject);
+          afterObject = Util.clone(beforeObject);
           fInsert(updateEngine.doUpdate(afterObject, update, query));
         } else {
           remove(dbo);

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -1,7 +1,5 @@
 package com.mongodb;
 
-import ch.qos.logback.classic.db.names.SimpleDBNameResolver;
-
 import com.foursquare.fongo.FongoException;
 import com.foursquare.fongo.impl.ExpressionParser;
 import com.foursquare.fongo.impl.Filter;

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -471,23 +471,29 @@ public class FongoTest {
   
   @Test
   public void testFindAndModifyReturnOld() {
-    DBCollection collection = newCollection();
-    collection.insert(new BasicDBObject("_id", 1).append("a", 1));
-    DBObject result = collection.findAndModify(new BasicDBObject("_id", 1), 
-        null, null, false, new BasicDBObject("$inc", new BasicDBObject("a", 1)), false, false);
-    
-    assertEquals(new BasicDBObject("_id", 1).append("a", 1), result);
-    assertEquals(new BasicDBObject("_id", 1).append("a", 2), collection.findOne());
+    final DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", 1).append("b", new BasicDBObject("c", 1)));
+
+    final BasicDBObject query = new BasicDBObject("_id", 1);
+    final BasicDBObject update = new BasicDBObject("$inc", new BasicDBObject("a", 1).append("b.c", 1));
+    System.out.println("update: " + update);
+    final DBObject result = collection.findAndModify(query, null, null, false, update, false, false);
+
+    assertEquals(new BasicDBObject("_id", 1).append("a", 1).append("b", new BasicDBObject("c", 1)), result);
+    assertEquals(new BasicDBObject("_id", 1).append("a", 2).append("b", new BasicDBObject("c", 2)), collection.findOne());
   }
-  
+
   @Test
   public void testFindAndModifyReturnNew() {
-    DBCollection collection = newCollection();
-    collection.insert(new BasicDBObject("_id", 1).append("a", 1));
-    DBObject result = collection.findAndModify(new BasicDBObject("_id", 1), 
-        null, null, false, new BasicDBObject("$inc", new BasicDBObject("a", 1)), true, false);
-    
-    assertEquals(new BasicDBObject("_id", 1).append("a", 2), result);
+    final DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", 1).append("b", new BasicDBObject("c", 1)));
+
+    final BasicDBObject query = new BasicDBObject("_id", 1);
+    final BasicDBObject update = new BasicDBObject("$inc", new BasicDBObject("a", 1).append("b.c", 1));
+    System.out.println("update: " + update);
+    final DBObject result = collection.findAndModify(query, null, null, false, update, true, false);
+
+    assertEquals(new BasicDBObject("_id", 1).append("a", 2).append("b", new BasicDBObject("c", 2)), result);
   }
   
   @Test


### PR DESCRIPTION
This pull request will fix #32 by using Mongo's native `copy()` methods in `BasicDBObject` and `BasicDBList`, which have deep clone behavior.
