### PR TITLE
Add test for regex matching on multiline docs. Refs #36.

### DIFF
--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -499,6 +499,21 @@ public class ExpressionParserTest {
   }
   
   @Test
+  public void testRegexOperatorWithMultilineDoc() {
+	BasicDBObject regexPattern = new BasicDBObject(ExpressionParser.REGEX, "foo.*Ster");
+    DBObject query = new BasicDBObject("a", regexPattern.append(ExpressionParser.REGEX_OPTIONS, "s"));
+    System.out.println(query);
+   
+    List<DBObject> results = doFilter(
+        query,
+        new BasicDBObject("a", "foo\nSter")
+    );
+    assertEquals(Arrays.<DBObject>asList(
+        new BasicDBObject("a", "foo\nSter")
+    ), results);
+  }
+  
+  @Test
   public void parseRegexFlags() {
     ExpressionParser ep = new ExpressionParser();
     assertEquals(Pattern.CASE_INSENSITIVE & Pattern.DOTALL & Pattern.COMMENTS, ep.parseRegexOptionsToPatternFlags("ixs"));


### PR DESCRIPTION
Showcases desired behaviour when matching a pattern using "$regex" on a document field that contains multiple lines of text. (When 's' option is used a dot character should match any character including a new line character '\n'.)

Desired behaviour:
Documents should match pattern like "line1.*line2" when they contain multiple lines of text, say "line1\nline2" and option 's' is used.

Observed behaviour:
No multiline documents match the pattern.

Note that this test does not pass because desired behaviour is not observed.
