### PR TITLE
correct scalatest to run with the good classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.mongodb</groupId>
       <artifactId>mongo-java-driver</artifactId>
-      <version>2.11.1</version>
+      <version>2.11.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -57,13 +57,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.6.6</version>
+      <version>1.7.5</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.13</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -149,7 +149,7 @@
           <configuration>
               <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
               <parallel>false</parallel>
-              <forkMode>never</forkMode>
+              <forkMode>once</forkMode>
               <junitxml>.</junitxml>
           </configuration>
           <executions>

--- a/src/test/scala/com/foursquare/fongo/FongoScalaTest.scala
+++ b/src/test/scala/com/foursquare/fongo/FongoScalaTest.scala
@@ -3,14 +3,23 @@ package com.foursquare.fongo
 import org.scalatest.Suite
 
 import org.scalatest._
+import com.mongodb.BasicDBObject
 
-class FongoScalaTest extends Suite {
+class FongoScalaTest extends FlatSpec with ShouldMatchers {
 
-  def testNpe() {
-    val fongo = new Fongo("InMemoryMongo")
-    val db = fongo.getDB("myDB")
-    val col = db.createCollection("myCollection", null)
-    val result = col.findOne()
-    assert(result == null)
-  }
+    "Fongo" should "not throw npe" in  {
+        val fongo = new Fongo("InMemoryMongo")
+        val db = fongo.getDB("myDB")
+        val col = db.createCollection("myCollection", null)
+        val result = col.findOne()
+        assert(result == null)
+    }
+
+    "Insert" should "work" in {
+        val collection = new Fongo("InMemoryMongo").getDB("myDB").createCollection("myCollection", null)
+
+        collection.insert(new BasicDBObject("basic", "basic"))
+
+        assert(1 === collection.count())
+    }
 }


### PR DESCRIPTION
Hi,

Scalatest doesn't run well test (I've got strange errors like :

`````` java
*** RUN ABORTED ***
  java.lang.IllegalAccessError: tried to access method com.mongodb.CommandResult.<init>(Lcom/mongodb/ServerAddress;)V from class com.mongodb.FongoDB
  at com.mongodb.FongoDB.okResult(FongoDB.java:131)
  at com.mongodb.FongoDBCollection.insertResult(FongoDBCollection.java:51)
  at com.mongodb.FongoDBCollection.insert(FongoDBCollection.java:87)
  at com.mongodb.FongoDBCollection.insert(FongoDBCollection.java:65)
  at com.mongodb.DBCollection.insert(DBCollection.java:60)
  at com.mongodb.DBCollection.insert(DBCollection.java:105)
  at com.foursquare.fongo.FongoScalaTest$$anonfun$2.apply$mcV$sp(FongoScalaTest.scala:21)
  at com.foursquare.fongo.FongoScalaTest$$anonfun$2.apply(FongoScalaTest.scala:18)
  at com.foursquare.fongo.FongoScalaTest$$anonfun$2.apply(FongoScalaTest.scala:18)
  at org.scalatest.FlatSpec$$anon$1.apply(FlatSpec.scala:3062)
```java

With fork = once, no more problem.

I update the mongodb driver, and the scalatest to go to FlatSpec instead of Suite (who is now deprecated)
``````
