### PR TITLE
Bug when using find() with limit()

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -15,12 +15,12 @@ import java.util.*;
 /**
  * fongo override of com.mongodb.DBCollection
  * you shouldn't need to use this class directly
- * 
+ *
  * @author jon
  */
 public class FongoDBCollection extends DBCollection {
   final static Logger LOG = LoggerFactory.getLogger(FongoDBCollection.class);
-  
+
   final static String ID_KEY = "_id";
   private final FongoDB fongoDb;
   // LinkedHashMap maintains insertion order
@@ -30,7 +30,7 @@ public class FongoDBCollection extends DBCollection {
   private final UpdateEngine updateEngine;
   private final boolean nonIdCollection;
   private final ObjectComparator objectComparator;
-  
+
   public FongoDBCollection(FongoDB db, String name) {
     super(db, name);
     this.fongoDb = db;
@@ -39,32 +39,32 @@ public class FongoDBCollection extends DBCollection {
     this.updateEngine = new UpdateEngine();
     this.objectComparator = new ObjectComparator();
   }
-  
+
   class ObjectComparator implements Comparator {
     @Override
     public int compare(Object o1, Object o2) {
       return expressionParser.compareObjects(o1, o2);
     }
   }
-  
+
   private CommandResult insertResult(int updateCount) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
     return result;
   }
-  
+
   private CommandResult updateResult(int updateCount, boolean updatedExisting) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
     result.put("updatedExisting", updatedExisting);
     return result;
   }
-  
+
   @Override
   public synchronized WriteResult insert(DBObject[] arr, WriteConcern concern, DBEncoder encoder) throws MongoException {
     return insert(Arrays.asList(arr), concern, encoder);
   }
-  
+
   @Override
   public WriteResult insert(List<DBObject> toInsert, WriteConcern concern, DBEncoder encoder) {
     for (DBObject obj : toInsert) {
@@ -78,15 +78,15 @@ public class FongoDBCollection extends DBCollection {
         if (enforceDuplicates(concern)) {
           throw new MongoException.DuplicateKey(fongoDb.errorResult(0, "Attempting to insert duplicate _id: " + id));
         } else {
-          // TODO(jon) log          
+          // TODO(jon) log
         }
       } else {
-        putSizeCheck(id, obj);        
+        putSizeCheck(id, obj);
       }
     }
     return new WriteResult(insertResult(toInsert.size()), concern);
   }
-  
+
   boolean enforceDuplicates(WriteConcern concern) {
     return !(WriteConcern.NONE.equals(concern) || WriteConcern.NORMAL.equals(concern));
   }
@@ -95,7 +95,7 @@ public class FongoDBCollection extends DBCollection {
     if (obj.get(ID_KEY) == null) {
       ObjectId id = new ObjectId();
       id.notNew();
-      if (!nonIdCollection){
+      if (!nonIdCollection) {
         obj.put(ID_KEY, id);
       }
       return id;
@@ -110,8 +110,8 @@ public class FongoDBCollection extends DBCollection {
     }
     objects.put(id, obj);
   }
-  
-  public DBObject filterLists(DBObject dbo){
+
+  public DBObject filterLists(DBObject dbo) {
     if (dbo == null) {
       return null;
     }
@@ -127,21 +127,21 @@ public class FongoDBCollection extends DBCollection {
     Object replacementValue = BSON.applyEncodingHooks(value);
     if (replacementValue instanceof DBObject) {
       replacementValue = filterLists((DBObject) replacementValue);
-    } else if (replacementValue instanceof List){
+    } else if (replacementValue instanceof List) {
       BasicDBList list = new BasicDBList();
-      for (Object listItem : (List) replacementValue){
+      for (Object listItem : (List) replacementValue) {
         list.add(replaceListAndMap(listItem));
       }
       replacementValue = list;
     } else if (replacementValue instanceof Object[]) {
       BasicDBList list = new BasicDBList();
-      for (Object listItem : (Object[]) replacementValue){
+      for (Object listItem : (Object[]) replacementValue) {
         list.add(replaceListAndMap(listItem));
       }
       replacementValue = list;
     } else if (replacementValue instanceof Map) {
       BasicDBObject newDbo = new BasicDBObject();
-      for (Map.Entry<String, Object>entry : (Set<Map.Entry<String, Object>>)((Map)replacementValue).entrySet()) {
+      for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) ((Map) replacementValue).entrySet()) {
         newDbo.put(entry.getKey(), replaceListAndMap(entry.getValue()));
       }
       replacementValue = newDbo;
@@ -158,16 +158,16 @@ public class FongoDBCollection extends DBCollection {
 
   @Override
   public synchronized WriteResult update(DBObject q, DBObject o, boolean upsert, boolean multi, WriteConcern concern,
-      DBEncoder encoder) throws MongoException {
+                                         DBEncoder encoder) throws MongoException {
 
     filterLists(q);
     filterLists(o);
 
-    if (LOG.isDebugEnabled()){
-      LOG.debug("update(" + q + ", " + o + ", " + upsert + ", " + multi +")");
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("update(" + q + ", " + o + ", " + upsert + ", " + multi + ")");
     }
 
-    if (o.containsField(ID_KEY) && q.containsField(ID_KEY) && !o.get(ID_KEY).equals(q.get(ID_KEY))){
+    if (o.containsField(ID_KEY) && q.containsField(ID_KEY) && !o.get(ID_KEY).equals(q.get(ID_KEY))) {
       throw new MongoException.DuplicateKey(fongoDb.errorResult(0, "can not change _id of a document " + ID_KEY));
     }
 
@@ -184,13 +184,13 @@ public class FongoDBCollection extends DBCollection {
     } else {
       List idsIn = idsIn(q);
       if (idOnlyUpdate && idsIn.size() > 0) {
-        for (Object id : idsIn){
+        for (Object id : idsIn) {
           DBObject existingObject = objects.get(id);
-          if (existingObject != null){
+          if (existingObject != null) {
             updatedDocuments++;
             updatedExisting = true;
             updateEngine.doUpdate(existingObject, o, q);
-            if (!multi){
+            if (!multi) {
               break;
             }
           }
@@ -198,63 +198,61 @@ public class FongoDBCollection extends DBCollection {
       } else {
         Filter filter = expressionParser.buildFilter(q);
         for (DBObject obj : objects.values()) {
-          if (filter.apply(obj)){
+          if (filter.apply(obj)) {
             updatedDocuments++;
             updatedExisting = true;
             updateEngine.doUpdate(obj, o, q);
-            if (!multi){
+            if (!multi) {
               break;
             }
           }
         }
       }
-      if (updatedDocuments == 0 && upsert){
+      if (updatedDocuments == 0 && upsert) {
         BasicDBObject newObject = createUpsertObject(q);
         fInsert(updateEngine.doUpdate(newObject, o, q));
       }
     }
     return new WriteResult(updateResult(updatedDocuments, updatedExisting), concern);
   }
-  
 
-  
-  
+
   public List idsIn(DBObject query) {
     Object idValue = query.get(ID_KEY);
     if (idValue == null || query.keySet().size() > 1) {
       return Collections.emptyList();
-    } else if (idValue instanceof DBObject ){
-      DBObject idDbObject = (DBObject)idValue;
-      List inList = (List)idDbObject.get(ExpressionParser.IN);
-      
+    } else if (idValue instanceof DBObject) {
+      DBObject idDbObject = (DBObject) idValue;
+      List inList = (List) idDbObject.get(ExpressionParser.IN);
+
       // I think sorting the inputed keys is a rough
       // approximation of how mongo creates the bounds for walking
       // the index.  It has the desired affect of returning results
       // in _id index order, but feels pretty hacky.
-      if (inList != null){
+      if (inList != null) {
         Object[] inListArray = inList.toArray(new Object[0]);
         // ids could be DBObjects, so we need a comparator that can handle that
         Arrays.sort(inListArray, objectComparator);
         return Arrays.asList(inListArray);
       }
-      if (!isNotUpdateCommand(idValue)){
+      if (!isNotUpdateCommand(idValue)) {
         return Collections.emptyList();
       }
-    } 
+    }
     return Collections.singletonList(idValue);
   }
 
-  protected  BasicDBObject createUpsertObject(DBObject q) {
+  protected BasicDBObject createUpsertObject(DBObject q) {
     BasicDBObject newObject = new BasicDBObject();
     List idsIn = idsIn(q);
-    
-    if (!idsIn.isEmpty()){
+
+    if (!idsIn.isEmpty()) {
       newObject.put(ID_KEY, idsIn.get(0));
     } else {
       BasicDBObject filteredQuery = new BasicDBObject();
-      for (String key : q.keySet()){
+      for (String key : q.keySet()) {
         Object value = q.get(key);
-        if (isNotUpdateCommand(value)){
+        if (isNotUpdateCommand(value)) {
           filteredQuery.put(key, value);
         }
       }
@@ -265,9 +263,9 @@ public class FongoDBCollection extends DBCollection {
 
   public boolean isNotUpdateCommand(Object value) {
     boolean okValue = true;
-    if (value instanceof DBObject){
-      for (String innerKey : ((DBObject) value).keySet()){
-        if (innerKey.startsWith("$")){
+    if (value instanceof DBObject) {
+      for (String innerKey : ((DBObject) value).keySet()) {
+        if (innerKey.startsWith("$")) {
           okValue = false;
         }
       }
@@ -282,22 +280,22 @@ public class FongoDBCollection extends DBCollection {
   @Override
   public synchronized WriteResult remove(DBObject o, WriteConcern concern, DBEncoder encoder) throws MongoException {
     filterLists(o);
-    if (LOG.isDebugEnabled()){
+    if (LOG.isDebugEnabled()) {
       LOG.debug("remove: " + o);
     }
     List idList = idsIn(o);
 
     int updatedDocuments = 0;
     if (!idList.isEmpty()) {
-      for (Object id : idList){
-        objects.remove(id);        
+      for (Object id : idList) {
+        objects.remove(id);
       }
       updatedDocuments = idList.size();
     } else {
       Filter filter = expressionParser.buildFilter(o);
       for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext(); ) {
         DBObject dbo = iter.next();
-        if (filter.apply(dbo)){
+        if (filter.apply(dbo)) {
           iter.remove();
           updatedDocuments++;
         }
@@ -316,7 +314,7 @@ public class FongoDBCollection extends DBCollection {
     StringBuilder sb = new StringBuilder();
     boolean firstLoop = true;
     for (String keyName : keys.keySet()) {
-      if (!firstLoop){
+      if (!firstLoop) {
         sb.append("_");
       }
       sb.append(keyName).append("_").append(keys.get(keyName));
@@ -328,53 +326,53 @@ public class FongoDBCollection extends DBCollection {
   }
 
   @Override
-  public DBObject findOne(DBObject ref, DBObject fields, DBObject orderBy, ReadPreference readPref ) {
+  public DBObject findOne(DBObject ref, DBObject fields, DBObject orderBy, ReadPreference readPref) {
     Iterator<DBObject> resultIterator = __find(ref, fields, 0, 1, -1, 0, readPref, null);
     return resultIterator.hasNext() ? resultIterator.next() : null;
   }
-  
+
   /**
    * note: encoder, decoder, readPref, options are ignored
    */
   @Override
   Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options,
-      ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
-    
+                            ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
+
     return __find(ref, fields, numToSkip, batchSize, limit, options, readPref, decoder);
   }
-  
+
   /**
    * note: decoder, readPref, options are ignored
    */
   @Override
   synchronized Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options,
-      ReadPreference readPref, DBDecoder decoder) throws MongoException {
+                                         ReadPreference readPref, DBDecoder decoder) throws MongoException {
     filterLists(ref);
-    if (LOG.isDebugEnabled()){
-      LOG.debug("find({}, {}).skip({}).limit({})", new Object[] { ref, fields, numToSkip, limit, });
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("find({}, {}).skip({}).limit({})", new Object[]{ref, fields, numToSkip, limit,});
       LOG.debug("the db looks like {}", objects);
     }
-    
+
     List idList = idsIn(ref);
     List<DBObject> results = new ArrayList<DBObject>();
-    
+
     if (!idList.isEmpty()) {
-      if (LOG.isDebugEnabled()){
+      if (LOG.isDebugEnabled()) {
         LOG.debug("find using id index only {}", idList);
       }
-      for (Object id : idList){
+      for (Object id : idList) {
         DBObject result = objects.get(id);
-        if (result != null){
-          results.add(result);          
+        if (result != null) {
+          results.add(result);
         }
       }
     } else {
       DBObject orderby = null;
       if (ref.containsField("$query") && ref.containsField("$orderby")) {
-        orderby = (DBObject)ref.get("$orderby");
-        ref = (DBObject)ref.get("$query");
+        orderby = (DBObject) ref.get("$orderby");
+        ref = (DBObject) ref.get("$query");
       }
-      
+
       Filter filter = expressionParser.buildFilter(ref);
       int foundCount = 0;
       int upperLimit = Integer.MAX_VALUE;
@@ -383,9 +381,10 @@ public class FongoDBCollection extends DBCollection {
       }
       int seen = 0;
       Collection<DBObject> objectsToSearch = sortObjects(orderby);
-      for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext() && foundCount <= upperLimit; seen++) {
+      // 20130719 for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext() && foundCount <= upperLimit; seen++) {
+      for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext() && foundCount < upperLimit; seen++) {
         DBObject dbo = iter.next();
-        if (seen >= numToSkip){
+        if (seen >= numToSkip) {
           if (filter.apply(dbo)) {
             foundCount++;
             results.add(dbo);
@@ -393,36 +392,36 @@ public class FongoDBCollection extends DBCollection {
         }
       }
     }
-    
+
     if (fields != null && !fields.keySet().isEmpty()) {
       LOG.info("applying projections {}", fields);
       results = applyProjections(results, fields);
     } else {
       results = copyResults(results);
     }
-    
+
     LOG.debug("found results {}", results);
 
     return results.iterator();
   }
-  
+
   private List<DBObject> copyResults(final List<DBObject> results) {
     final List<DBObject> ret = new ArrayList<DBObject>(results.size());
-    
+
     for (DBObject result : results) {
       ret.add(Util.clone(result));
     }
-    
+
     return ret;
   }
 
   private List<DBObject> applyProjections(List<DBObject> results, DBObject projection) {
     final List<DBObject> ret = new ArrayList<DBObject>(results.size());
-    
+
     for (DBObject result : results) {
       ret.add(applyProjections(result, projection));
     }
-    
+
     return ret;
   }
 
@@ -492,26 +491,27 @@ public class FongoDBCollection extends DBCollection {
     Collection<DBObject> objectsToSearch = objects.values();
     if (orderby != null) {
       final Set<String> orderbyKeySet = orderby.keySet();
-      if (!orderbyKeySet.isEmpty()){
-        DBObject[] objectsToSort = objects.values().toArray(new DBObject [0]);
+      if (!orderbyKeySet.isEmpty()) {
+        DBObject[] objectsToSort = objects.values().toArray(new DBObject[0]);
 
-        Arrays.sort(objectsToSort, new Comparator<DBObject>(){
+        Arrays.sort(objectsToSort, new Comparator<DBObject>() {
           @Override
           public int compare(DBObject o1, DBObject o2) {
             for (String sortKey : orderbyKeySet) {
               final List<String> path = Util.split(sortKey);
-              int sortDirection = (Integer)orderby.get(sortKey);
+              int sortDirection = (Integer) orderby.get(sortKey);
 
               List<Object> o1list = expressionParser.getEmbeddedValues(path, o1);
               List<Object> o2list = expressionParser.getEmbeddedValues(path, o2);
-              
+
               int compareValue = expressionParser.compareLists(o1list, o2list) * sortDirection;
-              if (compareValue != 0){
+              if (compareValue != 0) {
                 return compareValue;
               }
             }
             return 0;
-          }});
+          }
+        });
         objectsToSearch = Arrays.asList(objectsToSort);
       }
     }
@@ -521,9 +521,9 @@ public class FongoDBCollection extends DBCollection {
     return objectsToSearch;
   }
 
-  
+
   @Override
-  public synchronized long getCount(DBObject query, DBObject fields, long limit, long skip ) {
+  public synchronized long getCount(DBObject query, DBObject fields, long limit, long skip) {
     filterLists(query);
     Filter filter = query == null ? ExpressionParser.AllFilter : expressionParser.buildFilter(query);
     long count = 0;
@@ -532,19 +532,19 @@ public class FongoDBCollection extends DBCollection {
       upperLimit = limit;
     }
     int seen = 0;
-    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext() && count <= upperLimit;) {
+    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext() && count <= upperLimit; ) {
       DBObject value = iter.next();
       if (seen++ >= skip) {
-        if (filter.apply(value)){
+        if (filter.apply(value)) {
           count++;
         }
       }
     }
     return count;
   }
-  
+
   @Override
-  public synchronized long getCount(DBObject query, DBObject fields, ReadPreference readPrefs){
+  public synchronized long getCount(DBObject query, DBObject fields, ReadPreference readPrefs) {
     //as we're in memory we don't need to worry about readPrefs
     return getCount(query, fields, 0, 0);
   }
@@ -558,7 +558,7 @@ public class FongoDBCollection extends DBCollection {
     Collection<DBObject> objectsToSearch = sortObjects(sort);
     DBObject beforeObject = null;
     DBObject afterObject = null;
-    for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext();) {
+    for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext(); ) {
       DBObject dbo = iter.next();
       if (filter.apply(dbo)) {
         beforeObject = dbo;
@@ -571,40 +571,40 @@ public class FongoDBCollection extends DBCollection {
         }
       }
     }
-    if (beforeObject != null && !returnNew){
+    if (beforeObject != null && !returnNew) {
       return beforeObject;
     }
-    if (beforeObject == null && upsert && !remove){
+    if (beforeObject == null && upsert && !remove) {
       beforeObject = new BasicDBObject();
       afterObject = createUpsertObject(query);
       fInsert(updateEngine.doUpdate(afterObject, update, query));
     }
-    if (returnNew){
+    if (returnNew) {
       return Util.clone(afterObject);
     } else {
       return Util.clone(beforeObject);
     }
   }
-  
+
   @Override
   public synchronized List distinct(String key, DBObject query) {
     filterLists(query);
     List<Object> results = new ArrayList<Object>();
     Filter filter = expressionParser.buildFilter(query);
-    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext();) {
+    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext(); ) {
       DBObject value = iter.next();
-      if (filter.apply(value) && !results.contains(value.get(key))){
+      if (filter.apply(value) && !results.contains(value.get(key))) {
         results.add(value.get(key));
       }
     }
     return results;
   }
-  
+
   @Override
   public void dropIndexes(String name) throws MongoException {
     // do nothing
   }
-  
+
   @Override
   public void drop() {
     objects.clear();

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -15,12 +15,12 @@ import java.util.*;
 /**
  * fongo override of com.mongodb.DBCollection
  * you shouldn't need to use this class directly
- *
+ * 
  * @author jon
  */
 public class FongoDBCollection extends DBCollection {
   final static Logger LOG = LoggerFactory.getLogger(FongoDBCollection.class);
-
+  
   final static String ID_KEY = "_id";
   private final FongoDB fongoDb;
   // LinkedHashMap maintains insertion order
@@ -30,7 +30,7 @@ public class FongoDBCollection extends DBCollection {
   private final UpdateEngine updateEngine;
   private final boolean nonIdCollection;
   private final ObjectComparator objectComparator;
-
+  
   public FongoDBCollection(FongoDB db, String name) {
     super(db, name);
     this.fongoDb = db;
@@ -39,32 +39,32 @@ public class FongoDBCollection extends DBCollection {
     this.updateEngine = new UpdateEngine();
     this.objectComparator = new ObjectComparator();
   }
-
+  
   class ObjectComparator implements Comparator {
     @Override
     public int compare(Object o1, Object o2) {
       return expressionParser.compareObjects(o1, o2);
     }
   }
-
+  
   private CommandResult insertResult(int updateCount) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
     return result;
   }
-
+  
   private CommandResult updateResult(int updateCount, boolean updatedExisting) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
     result.put("updatedExisting", updatedExisting);
     return result;
   }
-
+  
   @Override
   public synchronized WriteResult insert(DBObject[] arr, WriteConcern concern, DBEncoder encoder) throws MongoException {
     return insert(Arrays.asList(arr), concern, encoder);
   }
-
+  
   @Override
   public WriteResult insert(List<DBObject> toInsert, WriteConcern concern, DBEncoder encoder) {
     for (DBObject obj : toInsert) {
@@ -78,15 +78,15 @@ public class FongoDBCollection extends DBCollection {
         if (enforceDuplicates(concern)) {
           throw new MongoException.DuplicateKey(fongoDb.errorResult(0, "Attempting to insert duplicate _id: " + id));
         } else {
-          // TODO(jon) log
+          // TODO(jon) log          
         }
       } else {
-        putSizeCheck(id, obj);
+        putSizeCheck(id, obj);        
       }
     }
     return new WriteResult(insertResult(toInsert.size()), concern);
   }
-
+  
   boolean enforceDuplicates(WriteConcern concern) {
     return !(WriteConcern.NONE.equals(concern) || WriteConcern.NORMAL.equals(concern));
   }
@@ -95,7 +95,7 @@ public class FongoDBCollection extends DBCollection {
     if (obj.get(ID_KEY) == null) {
       ObjectId id = new ObjectId();
       id.notNew();
-      if (!nonIdCollection) {
+      if (!nonIdCollection){
         obj.put(ID_KEY, id);
       }
       return id;
@@ -110,8 +110,8 @@ public class FongoDBCollection extends DBCollection {
     }
     objects.put(id, obj);
   }
-
-  public DBObject filterLists(DBObject dbo) {
+  
+  public DBObject filterLists(DBObject dbo){
     if (dbo == null) {
       return null;
     }
@@ -127,21 +127,21 @@ public class FongoDBCollection extends DBCollection {
     Object replacementValue = BSON.applyEncodingHooks(value);
     if (replacementValue instanceof DBObject) {
       replacementValue = filterLists((DBObject) replacementValue);
-    } else if (replacementValue instanceof List) {
+    } else if (replacementValue instanceof List){
       BasicDBList list = new BasicDBList();
-      for (Object listItem : (List) replacementValue) {
+      for (Object listItem : (List) replacementValue){
         list.add(replaceListAndMap(listItem));
       }
       replacementValue = list;
     } else if (replacementValue instanceof Object[]) {
       BasicDBList list = new BasicDBList();
-      for (Object listItem : (Object[]) replacementValue) {
+      for (Object listItem : (Object[]) replacementValue){
         list.add(replaceListAndMap(listItem));
       }
       replacementValue = list;
     } else if (replacementValue instanceof Map) {
       BasicDBObject newDbo = new BasicDBObject();
-      for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) ((Map) replacementValue).entrySet()) {
+      for (Map.Entry<String, Object>entry : (Set<Map.Entry<String, Object>>)((Map)replacementValue).entrySet()) {
         newDbo.put(entry.getKey(), replaceListAndMap(entry.getValue()));
       }
       replacementValue = newDbo;
@@ -158,16 +158,16 @@ public class FongoDBCollection extends DBCollection {
 
   @Override
   public synchronized WriteResult update(DBObject q, DBObject o, boolean upsert, boolean multi, WriteConcern concern,
-                                         DBEncoder encoder) throws MongoException {
+      DBEncoder encoder) throws MongoException {
 
     filterLists(q);
     filterLists(o);
 
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("update(" + q + ", " + o + ", " + upsert + ", " + multi + ")");
+    if (LOG.isDebugEnabled()){
+      LOG.debug("update(" + q + ", " + o + ", " + upsert + ", " + multi +")");
     }
 
-    if (o.containsField(ID_KEY) && q.containsField(ID_KEY) && !o.get(ID_KEY).equals(q.get(ID_KEY))) {
+    if (o.containsField(ID_KEY) && q.containsField(ID_KEY) && !o.get(ID_KEY).equals(q.get(ID_KEY))){
       throw new MongoException.DuplicateKey(fongoDb.errorResult(0, "can not change _id of a document " + ID_KEY));
     }
 
@@ -184,13 +184,13 @@ public class FongoDBCollection extends DBCollection {
     } else {
       List idsIn = idsIn(q);
       if (idOnlyUpdate && idsIn.size() > 0) {
-        for (Object id : idsIn) {
+        for (Object id : idsIn){
           DBObject existingObject = objects.get(id);
-          if (existingObject != null) {
+          if (existingObject != null){
             updatedDocuments++;
             updatedExisting = true;
             updateEngine.doUpdate(existingObject, o, q);
-            if (!multi) {
+            if (!multi){
               break;
             }
           }
@@ -198,61 +198,63 @@ public class FongoDBCollection extends DBCollection {
       } else {
         Filter filter = expressionParser.buildFilter(q);
         for (DBObject obj : objects.values()) {
-          if (filter.apply(obj)) {
+          if (filter.apply(obj)){
             updatedDocuments++;
             updatedExisting = true;
             updateEngine.doUpdate(obj, o, q);
-            if (!multi) {
+            if (!multi){
               break;
             }
           }
         }
       }
-      if (updatedDocuments == 0 && upsert) {
+      if (updatedDocuments == 0 && upsert){
         BasicDBObject newObject = createUpsertObject(q);
         fInsert(updateEngine.doUpdate(newObject, o, q));
       }
     }
     return new WriteResult(updateResult(updatedDocuments, updatedExisting), concern);
   }
+  
 
-
+  
+  
   public List idsIn(DBObject query) {
     Object idValue = query.get(ID_KEY);
     if (idValue == null || query.keySet().size() > 1) {
       return Collections.emptyList();
-    } else if (idValue instanceof DBObject) {
-      DBObject idDbObject = (DBObject) idValue;
-      List inList = (List) idDbObject.get(ExpressionParser.IN);
-
+    } else if (idValue instanceof DBObject ){
+      DBObject idDbObject = (DBObject)idValue;
+      List inList = (List)idDbObject.get(ExpressionParser.IN);
+      
       // I think sorting the inputed keys is a rough
       // approximation of how mongo creates the bounds for walking
       // the index.  It has the desired affect of returning results
       // in _id index order, but feels pretty hacky.
-      if (inList != null) {
+      if (inList != null){
         Object[] inListArray = inList.toArray(new Object[0]);
         // ids could be DBObjects, so we need a comparator that can handle that
         Arrays.sort(inListArray, objectComparator);
         return Arrays.asList(inListArray);
       }
-      if (!isNotUpdateCommand(idValue)) {
+      if (!isNotUpdateCommand(idValue)){
         return Collections.emptyList();
       }
-    }
+    } 
     return Collections.singletonList(idValue);
   }
 
-  protected BasicDBObject createUpsertObject(DBObject q) {
+  protected  BasicDBObject createUpsertObject(DBObject q) {
     BasicDBObject newObject = new BasicDBObject();
     List idsIn = idsIn(q);
-
-    if (!idsIn.isEmpty()) {
+    
+    if (!idsIn.isEmpty()){
       newObject.put(ID_KEY, idsIn.get(0));
     } else {
       BasicDBObject filteredQuery = new BasicDBObject();
-      for (String key : q.keySet()) {
+      for (String key : q.keySet()){
         Object value = q.get(key);
-        if (isNotUpdateCommand(value)) {
+        if (isNotUpdateCommand(value)){
           filteredQuery.put(key, value);
         }
       }
@@ -263,9 +265,9 @@ public class FongoDBCollection extends DBCollection {
 
   public boolean isNotUpdateCommand(Object value) {
     boolean okValue = true;
-    if (value instanceof DBObject) {
-      for (String innerKey : ((DBObject) value).keySet()) {
-        if (innerKey.startsWith("$")) {
+    if (value instanceof DBObject){
+      for (String innerKey : ((DBObject) value).keySet()){
+        if (innerKey.startsWith("$")){
           okValue = false;
         }
       }
@@ -280,22 +282,22 @@ public class FongoDBCollection extends DBCollection {
   @Override
   public synchronized WriteResult remove(DBObject o, WriteConcern concern, DBEncoder encoder) throws MongoException {
     filterLists(o);
-    if (LOG.isDebugEnabled()) {
+    if (LOG.isDebugEnabled()){
       LOG.debug("remove: " + o);
     }
     List idList = idsIn(o);
 
     int updatedDocuments = 0;
     if (!idList.isEmpty()) {
-      for (Object id : idList) {
-        objects.remove(id);
+      for (Object id : idList){
+        objects.remove(id);        
       }
       updatedDocuments = idList.size();
     } else {
       Filter filter = expressionParser.buildFilter(o);
       for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext(); ) {
         DBObject dbo = iter.next();
-        if (filter.apply(dbo)) {
+        if (filter.apply(dbo)){
           iter.remove();
           updatedDocuments++;
         }
@@ -314,7 +316,7 @@ public class FongoDBCollection extends DBCollection {
     StringBuilder sb = new StringBuilder();
     boolean firstLoop = true;
     for (String keyName : keys.keySet()) {
-      if (!firstLoop) {
+      if (!firstLoop){
         sb.append("_");
       }
       sb.append(keyName).append("_").append(keys.get(keyName));
@@ -326,53 +328,53 @@ public class FongoDBCollection extends DBCollection {
   }
 
   @Override
-  public DBObject findOne(DBObject ref, DBObject fields, DBObject orderBy, ReadPreference readPref) {
+  public DBObject findOne(DBObject ref, DBObject fields, DBObject orderBy, ReadPreference readPref ) {
     Iterator<DBObject> resultIterator = __find(ref, fields, 0, 1, -1, 0, readPref, null);
     return resultIterator.hasNext() ? resultIterator.next() : null;
   }
-
+  
   /**
    * note: encoder, decoder, readPref, options are ignored
    */
   @Override
   Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options,
-                            ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
-
+      ReadPreference readPref, DBDecoder decoder, DBEncoder encoder) {
+    
     return __find(ref, fields, numToSkip, batchSize, limit, options, readPref, decoder);
   }
-
+  
   /**
    * note: decoder, readPref, options are ignored
    */
   @Override
   synchronized Iterator<DBObject> __find(DBObject ref, DBObject fields, int numToSkip, int batchSize, int limit, int options,
-                                         ReadPreference readPref, DBDecoder decoder) throws MongoException {
+      ReadPreference readPref, DBDecoder decoder) throws MongoException {
     filterLists(ref);
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("find({}, {}).skip({}).limit({})", new Object[]{ref, fields, numToSkip, limit,});
+    if (LOG.isDebugEnabled()){
+      LOG.debug("find({}, {}).skip({}).limit({})", new Object[] { ref, fields, numToSkip, limit, });
       LOG.debug("the db looks like {}", objects);
     }
-
+    
     List idList = idsIn(ref);
     List<DBObject> results = new ArrayList<DBObject>();
-
+    
     if (!idList.isEmpty()) {
-      if (LOG.isDebugEnabled()) {
+      if (LOG.isDebugEnabled()){
         LOG.debug("find using id index only {}", idList);
       }
-      for (Object id : idList) {
+      for (Object id : idList){
         DBObject result = objects.get(id);
-        if (result != null) {
-          results.add(result);
+        if (result != null){
+          results.add(result);          
         }
       }
     } else {
       DBObject orderby = null;
       if (ref.containsField("$query") && ref.containsField("$orderby")) {
-        orderby = (DBObject) ref.get("$orderby");
-        ref = (DBObject) ref.get("$query");
+        orderby = (DBObject)ref.get("$orderby");
+        ref = (DBObject)ref.get("$query");
       }
-
+      
       Filter filter = expressionParser.buildFilter(ref);
       int foundCount = 0;
       int upperLimit = Integer.MAX_VALUE;
@@ -381,10 +383,9 @@ public class FongoDBCollection extends DBCollection {
       }
       int seen = 0;
       Collection<DBObject> objectsToSearch = sortObjects(orderby);
-      // 20130719 for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext() && foundCount <= upperLimit; seen++) {
       for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext() && foundCount < upperLimit; seen++) {
         DBObject dbo = iter.next();
-        if (seen >= numToSkip) {
+        if (seen >= numToSkip){
           if (filter.apply(dbo)) {
             foundCount++;
             results.add(dbo);
@@ -392,36 +393,36 @@ public class FongoDBCollection extends DBCollection {
         }
       }
     }
-
+    
     if (fields != null && !fields.keySet().isEmpty()) {
       LOG.info("applying projections {}", fields);
       results = applyProjections(results, fields);
     } else {
       results = copyResults(results);
     }
-
+    
     LOG.debug("found results {}", results);
 
     return results.iterator();
   }
-
+  
   private List<DBObject> copyResults(final List<DBObject> results) {
     final List<DBObject> ret = new ArrayList<DBObject>(results.size());
-
+    
     for (DBObject result : results) {
       ret.add(Util.clone(result));
     }
-
+    
     return ret;
   }
 
   private List<DBObject> applyProjections(List<DBObject> results, DBObject projection) {
     final List<DBObject> ret = new ArrayList<DBObject>(results.size());
-
+    
     for (DBObject result : results) {
       ret.add(applyProjections(result, projection));
     }
-
+    
     return ret;
   }
 
@@ -491,27 +492,26 @@ public class FongoDBCollection extends DBCollection {
     Collection<DBObject> objectsToSearch = objects.values();
     if (orderby != null) {
       final Set<String> orderbyKeySet = orderby.keySet();
-      if (!orderbyKeySet.isEmpty()) {
-        DBObject[] objectsToSort = objects.values().toArray(new DBObject[0]);
+      if (!orderbyKeySet.isEmpty()){
+        DBObject[] objectsToSort = objects.values().toArray(new DBObject [0]);
 
-        Arrays.sort(objectsToSort, new Comparator<DBObject>() {
+        Arrays.sort(objectsToSort, new Comparator<DBObject>(){
           @Override
           public int compare(DBObject o1, DBObject o2) {
             for (String sortKey : orderbyKeySet) {
               final List<String> path = Util.split(sortKey);
-              int sortDirection = (Integer) orderby.get(sortKey);
+              int sortDirection = (Integer)orderby.get(sortKey);
 
               List<Object> o1list = expressionParser.getEmbeddedValues(path, o1);
               List<Object> o2list = expressionParser.getEmbeddedValues(path, o2);
-
+              
               int compareValue = expressionParser.compareLists(o1list, o2list) * sortDirection;
-              if (compareValue != 0) {
+              if (compareValue != 0){
                 return compareValue;
               }
             }
             return 0;
-          }
-        });
+          }});
         objectsToSearch = Arrays.asList(objectsToSort);
       }
     }
@@ -521,9 +521,9 @@ public class FongoDBCollection extends DBCollection {
     return objectsToSearch;
   }
 
-
+  
   @Override
-  public synchronized long getCount(DBObject query, DBObject fields, long limit, long skip) {
+  public synchronized long getCount(DBObject query, DBObject fields, long limit, long skip ) {
     filterLists(query);
     Filter filter = query == null ? ExpressionParser.AllFilter : expressionParser.buildFilter(query);
     long count = 0;
@@ -532,19 +532,19 @@ public class FongoDBCollection extends DBCollection {
       upperLimit = limit;
     }
     int seen = 0;
-    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext() && count <= upperLimit; ) {
+    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext() && count <= upperLimit;) {
       DBObject value = iter.next();
       if (seen++ >= skip) {
-        if (filter.apply(value)) {
+        if (filter.apply(value)){
           count++;
         }
       }
     }
     return count;
   }
-
+  
   @Override
-  public synchronized long getCount(DBObject query, DBObject fields, ReadPreference readPrefs) {
+  public synchronized long getCount(DBObject query, DBObject fields, ReadPreference readPrefs){
     //as we're in memory we don't need to worry about readPrefs
     return getCount(query, fields, 0, 0);
   }
@@ -558,7 +558,7 @@ public class FongoDBCollection extends DBCollection {
     Collection<DBObject> objectsToSearch = sortObjects(sort);
     DBObject beforeObject = null;
     DBObject afterObject = null;
-    for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext(); ) {
+    for (Iterator<DBObject> iter = objectsToSearch.iterator(); iter.hasNext();) {
       DBObject dbo = iter.next();
       if (filter.apply(dbo)) {
         beforeObject = dbo;
@@ -571,40 +571,40 @@ public class FongoDBCollection extends DBCollection {
         }
       }
     }
-    if (beforeObject != null && !returnNew) {
+    if (beforeObject != null && !returnNew){
       return beforeObject;
     }
-    if (beforeObject == null && upsert && !remove) {
+    if (beforeObject == null && upsert && !remove){
       beforeObject = new BasicDBObject();
       afterObject = createUpsertObject(query);
       fInsert(updateEngine.doUpdate(afterObject, update, query));
     }
-    if (returnNew) {
+    if (returnNew){
       return Util.clone(afterObject);
     } else {
       return Util.clone(beforeObject);
     }
   }
-
+  
   @Override
   public synchronized List distinct(String key, DBObject query) {
     filterLists(query);
     List<Object> results = new ArrayList<Object>();
     Filter filter = expressionParser.buildFilter(query);
-    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext(); ) {
+    for (Iterator<DBObject> iter = objects.values().iterator(); iter.hasNext();) {
       DBObject value = iter.next();
-      if (filter.apply(value) && !results.contains(value.get(key))) {
+      if (filter.apply(value) && !results.contains(value.get(key))){
         results.add(value.get(key));
       }
     }
     return results;
   }
-
+  
   @Override
   public void dropIndexes(String name) throws MongoException {
     // do nothing
   }
-
+  
   @Override
   public void drop() {
     objects.clear();

--- a/src/test/java/com/mongodb/FongoLimitSkipTest.java
+++ b/src/test/java/com/mongodb/FongoLimitSkipTest.java
@@ -1,0 +1,205 @@
+package com.mongodb;
+
+import com.foursquare.fongo.Fongo;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Project XXX
+ * <p/>
+ * Date: 7/19/13 Time: 10:25 AM
+ *
+ * @author a554998
+ */
+public class FongoLimitSkipTest {
+
+  private static final transient Logger LOG = LoggerFactory.getLogger(FongoLimitSkipTest.class);
+
+  private Fongo fongo;
+  private DB db;
+  private DBCollection coll;
+
+  @Before
+  public void setup() {
+
+    fongo = new Fongo("mongo server testLimitSkip");
+
+    db = fongo.getDB("mydb");
+    coll = db.getCollection("mycollection");
+
+    // Insert 9 objects
+    for (int i = 9; i > 0; i--) {
+      DBObject dbo = (new BasicTestObject("" + i, i, "index=" + i)).asDBObject();
+      coll.insert(dbo);
+    }
+
+  }
+
+  @After
+  public void teardown() {
+    db.dropDatabase();
+  }
+
+  @Test
+  public void testLimit() {
+
+    LOG.info("Test find with limit");
+    // Show & count objects in db
+    DBCursor cursor = coll.find();
+    int count = scanCursor(cursor);
+    assert (count == 9);
+
+    // Set a cursor limit of 8 & check that 8 entries are returned
+    cursor = coll.find().limit(8);
+    count = scanCursor(cursor);
+    assert (count == 8);
+
+    // Now set the limit to 3 & check 3 entries are returned
+    cursor = coll.find().limit(3); // Set cursor limit to 3
+    count = scanCursor(cursor);
+    assert (count == 3);
+
+    // Repeat last test & check the expected entries are returned
+    cursor = coll.find().limit(3);
+    assert (9 == (Integer) cursor.next().get("intValue"));
+    assert (8 == (Integer) cursor.next().get("intValue"));
+    assert (7 == (Integer) cursor.next().get("intValue"));
+
+  }
+
+  @Test
+  public void testSkip() {
+
+    LOG.info("Test find with skip");
+    // Show & count objects in db
+    DBCursor cursor = coll.find();
+    int count = scanCursor(cursor);
+    assert (count == 9);
+
+    // Set skip=8 & check that 1 entry is returned
+    cursor = coll.find().skip(8);
+    count = scanCursor(cursor);
+    assert (count == 1);
+
+    // Now set skip=7 & check 2 entries are returned
+    cursor = coll.find().skip(7); // Set cursor limit to 3
+    count = scanCursor(cursor);
+    assert (count == 2);
+
+    // Repeat last test & check the expected entries are returned
+    cursor = coll.find().skip(7);
+    assert (2 == (Integer) cursor.next().get("intValue"));
+    assert (1 == (Integer) cursor.next().get("intValue"));
+
+  }
+
+  @Test
+  public void testLimitAndSkip() {
+
+    LOG.info("Test find with limit and skip");
+    // Show & count objects in db
+    DBCursor cursor = coll.find();
+    int count = scanCursor(cursor);
+    assert (count == 9);
+
+    // Set limit=3, skip=4 & check that 3 entries is returned
+    cursor = coll.find().limit(3).skip(4);
+    count = scanCursor(cursor);
+    assert (count == 3);
+
+    // Now set limit=3, skip=7 & check 2 entries are returned
+    cursor = coll.find().limit(3).skip(7); // Set cursor limit to 3
+    count = scanCursor(cursor);
+    assert (count == 2);
+
+    // Repeat last test & check the expected entries are returned
+    cursor = coll.find().limit(3).skip(7);
+    assert (2 == (Integer) cursor.next().get("intValue"));
+    assert (1 == (Integer) cursor.next().get("intValue"));
+
+    // Set limit 3, skip 10 - nothing should be returned
+    cursor = coll.find().limit(3).skip(10);
+    LOG.debug("cursor = {}", cursor);
+    count = scanCursor(cursor);
+    assert (count == 0);
+
+  }
+
+  private int scanCursor(DBCursor cursor) {
+    // We count here becuase we can't use the DBCursor count() method
+    int i = 0;
+    while (cursor.hasNext()) {
+      i++;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(cursor.next().toString());
+      } else {
+        cursor.next();
+      }
+    }
+    LOG.debug("Cursor contains {} entries", i);
+    return i;
+  }
+
+}
+
+/**
+ * Basic object for test purposes.
+ * Date: 7/10/13 Time: 3:13 PM
+ *
+ * @author: a554998
+ */
+class BasicTestObject {
+  String id;
+  int intValue;
+  String stringValue;
+
+  public BasicTestObject() {
+    new BasicTestObject("", 0, "");
+  }
+
+  public BasicTestObject(String id, int intValue, String stringValue) {
+    this.id = id;
+    this.intValue = intValue;
+    this.stringValue = stringValue;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public int getIntValue() {
+    return intValue;
+  }
+
+  public void setIntValue(int intValue) {
+    this.intValue = intValue;
+  }
+
+  public String getStringValue() {
+    return stringValue;
+  }
+
+  public void setStringValue(String stringValue) {
+    this.stringValue = stringValue;
+  }
+
+  @Override
+  public String toString() {
+    return this.getId() + " / " + this.getIntValue() + " / " + this.getStringValue();
+  }
+
+  public DBObject asDBObject() {
+    DBObject dbo = new BasicDBObject("_id", this.getId())
+        .append("intValue", this.getIntValue())
+        .append("stringValue", this.getStringValue());
+    return dbo;
+  }
+}
+


### PR DESCRIPTION
I think there's a tiny bug when applying limit() to a find().

I've added a small test case for both limit and skip and, as you can see, the fix is a one-liner (assuming that this is actually a bug - I'm a little suspicious since all I had to do was change <= to <).

While looking into this I also discovered that DBCursor.count() always seems to return a count corresponding to an empty find() ie the whole collection, irrespective of the particular cursor involved (which will often represent a subset of the collection). I'm not sure if that's a bug or if Fongo just doesn't support the full DBCursor functionality so I haven't reported it as an issue. If you do want me to enter an issue for this just let me know. BTW, I have no idea how to fix this.
