### PR TITLE
unable scalac for execution compile and make only bytecode 1.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,11 +136,29 @@
           <executions>
               <execution>
                   <goals>
-                      <goal>compile</goal>
                       <goal>testCompile</goal>
                   </goals>
               </execution>
           </executions>
+          <configuration>
+              <javacArgs>
+                <javacArg>-source</javacArg>
+                <javacArg>1.6</javacArg>
+                <javacArg>-target</javacArg>
+                <javacArg>1.6</javacArg>
+              </javacArgs>
+              <jvmArgs>
+                <jvmArg>-Xms64m</jvmArg>
+                <jvmArg>-Xmx1024m</jvmArg>
+                <!--jvmArg>-Dscala.timings=true</jvmArg -->
+              </jvmArgs>
+              <args>
+                <arg>-target:jvm-1.6</arg>
+                <arg>-unchecked</arg>
+                <arg>-deprecation</arg>
+                <arg>-feature</arg>
+              </args>
+          </configuration>
       </plugin>
       <plugin>
           <groupId>org.scalatest</groupId>


### PR DESCRIPTION
Hi,

scalac "compile" source with the installed jdk.

With this config, he compile only test and set targetjvm to 1.6.
