### PR TITLE
default writeConcert to ACKNOWLEDGED

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -88,7 +88,9 @@ public class FongoDBCollection extends DBCollection {
   }
 
   boolean enforceDuplicates(WriteConcern concern) {
-    return !(WriteConcern.NONE.equals(concern) || WriteConcern.NORMAL.equals(concern));
+    WriteConcern writeConcern = concern == null ? getWriteConcern() : concern;
+    return writeConcern._w instanceof Number && ((Number) writeConcern._w).intValue() > 0;
+//    return  !(WriteConcern.NONE.equals(concern) || WriteConcern.NORMAL.equals(concern)); // UNACKNOWLEDGED and ERRORS_IGNORED missed.
   }
 
   public Object putIdIfNotPresent(DBObject obj) {

--- a/src/main/java/com/mongodb/MockMongoClient.java
+++ b/src/main/java/com/mongodb/MockMongoClient.java
@@ -7,10 +7,10 @@ import java.util.List;
 import org.objenesis.ObjenesisStd;
 
 public class MockMongoClient extends MongoClient {
-  
+
   // this is immutable 
   private final static MongoClientOptions clientOptions = MongoClientOptions.builder().build();
-  
+
   private Fongo fongo;
   private MongoOptions options;
 
@@ -19,13 +19,15 @@ public class MockMongoClient extends MongoClient {
     MockMongoClient client = (MockMongoClient) new ObjenesisStd().getInstantiatorOf(MockMongoClient.class).newInstance();
     client.options = new MongoOptions(clientOptions);
     client.fongo = fongo;
+    // ObjenesisStd doesn't call constructor and doesn't initialize variables.
+    client.setWriteConcern(clientOptions.getWriteConcern());
     return client;
   }
-  
+
   public MockMongoClient() throws UnknownHostException {
 
   }
-  
+
   @Override
   public String toString() {
     return fongo.toString();
@@ -55,17 +57,17 @@ public class MockMongoClient extends MongoClient {
   public void dropDatabase(String dbName) {
     fongo.dropDatabase(dbName);
   }
-  
+
   @Override
   boolean isMongosConnection() {
     return false;
   }
-  
+
   @Override
   public MongoOptions getMongoOptions() {
-    return options ;
+    return options;
   }
-  
+
   @Override
   public MongoClientOptions getMongoClientOptions() {
     return clientOptions;

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -982,6 +982,31 @@ public class FongoTest {
     }
   }
 
+  // Don't know why, but request by _id only return document event if limit is set
+  @Test
+  public void testFindLimit0ById() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", "jon").append("name", "hoff"));
+    List<DBObject> result = collection.find().limit(0).toArray();
+    assertNotNull(result);
+    assertEquals(1, result.size());
+  }
+
+  // Don't know why, but request by _id only return document even if skip is set
+  @Test
+  public void testFindSkip1yId() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("_id", "jon").append("name", "hoff"));
+    List<DBObject> result = collection.find(new BasicDBObject("_id", "jon")).skip(1).toArray();
+    assertNotNull(result);
+    assertEquals(1, result.size());
+  }
+
+  @Test
+  public void testWriteConcern() {
+    assertNotNull(newFongo().getWriteConcern());
+  }
+
   static class Seq {
     Object[] data;
     Seq(Object... data) { this.data = data; }


### PR DESCRIPTION
Hi,

the new "Fongo" has a writeConcert to "null".

Add two test from real life, if you know why 

``` javascript
db.fongo.insert({_id:1})
db.find({id:1}).skip(1).toArray()  => return {_id:1}
```

it will help me..

I suspect an "index scan only", I'm not sure. any idea ?
