### PR TITLE
_id must go first + test for updating accross indexes

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/Index.java
+++ b/src/main/java/com/foursquare/fongo/impl/Index.java
@@ -86,7 +86,7 @@ public class Index {
       if (mapValues.containsKey(key)) {
         return extractFields(object, key.keySet());
       }
-      mapValues.put(key, Collections.singletonList(object));
+      mapValues.put(key, Collections.singletonList(object)); // DO NOT CLONE !
     } else {
       // Extract previous values
       List<DBObject> values = mapValues.get(key);
@@ -97,7 +97,7 @@ public class Index {
       }
 
       // Add to values.
-      values.add(object);
+      values.add(object); // DO NOT CLONE ! Indexes must share the same object.
     }
     return Collections.emptyList();
   }
@@ -186,7 +186,7 @@ public class Index {
       if (filterKey.apply(entry.getKey())) {
         for (DBObject object : entry.getValue()) {
           if (filter.apply(object)) {
-            result.add(object);
+            result.add(object); // DO NOT CLONE ! need for update.
           }
         }
       }

--- a/src/main/java/com/foursquare/fongo/impl/Util.java
+++ b/src/main/java/com/foursquare/fongo/impl/Util.java
@@ -3,10 +3,13 @@ package com.foursquare.fongo.impl;
 import com.mongodb.BasicDBList;
 import com.mongodb.BasicDBObject;
 import com.mongodb.DBObject;
+import com.mongodb.FongoDBCollection;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 public class Util {
 
@@ -118,8 +121,8 @@ public class Util {
       return path;
     }
   }
-  
-  public static boolean isPositiveInt(String s){
+
+  public static boolean isPositiveInt(String s) {
     for (int i = 0; i < s.length(); i++) {
       char c = s.charAt(i);
       if (c < '0' || c > '9') {
@@ -133,7 +136,7 @@ public class Util {
     if (source == null) {
       return null;
     }
-    
+
     if (source instanceof BasicDBObject) {
       @SuppressWarnings("unchecked")
       T clone = (T) ((BasicDBObject) source).copy();
@@ -147,5 +150,31 @@ public class Util {
     }
 
     throw new IllegalArgumentException("Don't know how to clone: " + source);
+  }
+
+  // When inserting, MongoDB set _id in first place.
+  public static DBObject cloneIdFirst(DBObject source) {
+    if (source == null) {
+      return null;
+    }
+
+    // copy field values into new object
+    DBObject newobj = new BasicDBObject();
+    if (source.containsField(FongoDBCollection.ID_KEY)) {
+      newobj.put(FongoDBCollection.ID_KEY, source.get(FongoDBCollection.ID_KEY));
+    }
+    // need to clone the sub obj
+    for (Map.Entry<String, Object> entry : (Set<Map.Entry<String, Object>>) source.toMap().entrySet()) {
+      String field = entry.getKey();
+      Object val = entry.getValue();
+      if (val instanceof BasicDBObject) {
+        newobj.put(field, ((BasicDBObject) val).copy());
+      } else if (val instanceof BasicDBList) {
+        newobj.put(field, ((BasicDBList) val).copy());
+      } else {
+        newobj.put(field, val);
+      }
+    }
+    return newobj;
   }
 }

--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -56,17 +56,6 @@ public class FongoDBCollection extends DBCollection {
     this.indexes.add(_idIndex);
   }
 
-  private static class KeyIndex {
-    private final Set<String> fields;
-
-    private final DBObject keys;
-
-    private KeyIndex(DBObject keys) {
-      this.keys = Util.clone(keys);
-      this.fields = this.keys.keySet();
-    }
-  }
-
   private CommandResult insertResult(int updateCount) {
     CommandResult result = fongoDb.okResult();
     result.put("n", updateCount);
@@ -747,10 +736,11 @@ public class FongoDBCollection extends DBCollection {
       }
     }
 
+    DBObject idFirst = Util.cloneIdFirst(object);
     Set<String> oldQueryFields = oldObject == null ? Collections.<String>emptySet() : oldObject.keySet();
     for (Index index : indexes) {
       if (index.canHandle(queryFields)) {
-        index.addOrUpdate(object, oldObject);
+        index.addOrUpdate(idFirst, oldObject);
       } else if (index.canHandle(oldQueryFields))
         // In case of update and removing a field, we must remove from the index.
         index.remove(oldObject);

--- a/src/test/java/com/foursquare/fongo/FongoIndexTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoIndexTest.java
@@ -7,6 +7,7 @@ import com.mongodb.DBCollection;
 import com.mongodb.DBCursor;
 import com.mongodb.DBObject;
 import com.mongodb.FongoDBCollection;
+import com.mongodb.MongoClient;
 import com.mongodb.MongoException;
 import java.util.Arrays;
 import java.util.List;
@@ -495,6 +496,32 @@ public class FongoIndexTest {
     ), cursor.toArray());
   }
 
+  @Test
+  public void testUpdateMustModifyAllIndexes() throws Exception {
+    DBCollection collection = FongoTest.newCollection();
+    collection.insert(new BasicDBObject("date", 1).append("name", "jon").append("_id", 1));
+    collection.ensureIndex(new BasicDBObject("date", 1));
+    collection.ensureIndex(new BasicDBObject("name", 1));
+
+    Index indexDate = getIndex(collection, "date_1");
+    Index indexName = getIndex(collection, "name_1");
+
+    // Now, modify an object.
+    collection.update(new BasicDBObject("_id", 1), new BasicDBObject("$set", new BasicDBObject("name", "will")));
+    assertEquals(0, indexDate.getLookupCount());
+    assertEquals(0, indexName.getLookupCount());
+
+    // Find in with index "name"
+    assertEquals(new BasicDBObject("date", 1).append("name", "will").append("_id", 1), collection.findOne(new BasicDBObject("name", "will")));
+    assertEquals(1, indexName.getLookupCount());
+    assertEquals(0, indexDate.getLookupCount());
+    assertEquals(new BasicDBObject("date", 1).append("name", "will").append("_id", 1), collection.findOne(new BasicDBObject("date", 1)));
+    assertEquals(1, indexName.getLookupCount());
+    assertEquals(1, indexDate.getLookupCount());
+    assertEquals(new BasicDBObject("date", 1).append("name", "will").append("_id", 1), collection.findOne(new BasicDBObject("_id", 1)));
+    assertEquals(1, indexDate.getLookupCount());
+    assertEquals(1, indexName.getLookupCount());
+  }
 
   private Index getIndex(DBCollection collection, String name) {
     FongoDBCollection fongoDBCollection = (FongoDBCollection) collection;

--- a/src/test/java/com/foursquare/fongo/FongoTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoTest.java
@@ -667,7 +667,7 @@ public class FongoTest {
     DBCollection coll = newCollection();
     assertNull("should return null if nothing was found", coll.findAndRemove(new BasicDBObject()));
   }
-  
+
   @Test
   public void testFindAndModifyRemove() {
     DBCollection collection = newCollection();
@@ -1116,6 +1116,21 @@ public class FongoTest {
     assertEquals(WriteConcern.FSYNC_SAFE, fongo.getWriteConcern());
   }
 
+  // Id is always the first field.
+  @Test
+  public void shouldInsertIdFirst() throws Exception {
+    DBCollection collection = newCollection();
+    collection.insert(new BasicDBObject("date", 1).append("_id", new ObjectId()));
+    collection.insert(new BasicDBObject("date", 2).append("_id", new ObjectId()));
+    collection.insert(new BasicDBObject("date", 3).append("_id", new ObjectId()));
+
+    //
+    List<DBObject> result = collection.find().toArray();
+    for (DBObject object : result) {
+      // The _id field is always the first.
+      assertEquals("_id", object.toMap().keySet().iterator().next());
+    }
+  }
 
   static class Seq {
     Object[] data;


### PR DESCRIPTION
Hi,

MongoDB store _id first when inserting values : 

``` javascript
connecting to: test
> db.fongo.remove();
> db.fongo.insert({date:1, _id:1})
> db.fongo.find();
{ "_id" : 1, "date" : 1 }
```
- one test to check if update works againts indexes.
