### PR TITLE
Correct inner index

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/Index.java
+++ b/src/main/java/com/foursquare/fongo/impl/Index.java
@@ -159,10 +159,12 @@ public class Index {
    */
   public synchronized List<List<Object>> addAll(Iterable<DBObject> objects) {
     for (DBObject object : objects) {
-      List<List<Object>> nonUnique = addOrUpdate(object, null);
-      // TODO(twillouer) : must handle writeConcern.
-      if (!nonUnique.isEmpty()) {
-        return nonUnique;
+      if (canHandle(object.keySet())) {
+        List<List<Object>> nonUnique = addOrUpdate(object, null);
+        // TODO(twillouer) : must handle writeConcern.
+        if (!nonUnique.isEmpty()) {
+          return nonUnique;
+        }
       }
     }
     return Collections.emptyList();

--- a/src/test/java/com/foursquare/fongo/FongoIndexTest.java
+++ b/src/test/java/com/foursquare/fongo/FongoIndexTest.java
@@ -15,6 +15,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -521,6 +522,59 @@ public class FongoIndexTest {
     assertEquals(new BasicDBObject("date", 1).append("name", "will").append("_id", 1), collection.findOne(new BasicDBObject("_id", 1)));
     assertEquals(1, indexDate.getLookupCount());
     assertEquals(1, indexName.getLookupCount());
+  }
+
+  @Test
+  @Ignore("strange index, Mongo doen't handle but no exception.")
+  public void testInnerIndex() throws Exception {
+    DBCollection collection = FongoTest.newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", new BasicDBObject("n", 1)));
+
+    assertEquals(
+        new BasicDBObject("_id", 1).append("a", new BasicDBObject("n", 1)),
+        collection.findOne(new BasicDBObject("a.n", 1))
+    );
+
+    collection.ensureIndex(new BasicDBObject("a.n", 1));
+    Index index = getIndex(collection, "a.n_1");
+    assertEquals(
+        new BasicDBObject("_id", 1).append("a", new BasicDBObject("n", 1)),
+        collection.findOne(new BasicDBObject("a.n", 1))
+    );
+    assertEquals(1, index.getLookupCount());
+  }
+
+  @Test
+  public void testStrangeIndexThrowException() throws Exception {
+    exception.expect(MongoException.class);
+    DBCollection collection = FongoTest.newCollection();
+    collection.ensureIndex(new BasicDBObject("a", new BasicDBObject("n", 1)));
+
+    // Code : 10098
+  }
+
+  // Creating an index after inserting into a collection must add records only if necessary
+  @Test
+  public void testCreateIndexLater() throws Exception {
+    DBCollection collection = FongoTest.newCollection();
+    collection.insert(new BasicDBObject("_id", 1).append("a", 1));
+    collection.insert(new BasicDBObject("_id", 2));
+    collection.ensureIndex(new BasicDBObject("a", 1));
+
+    Index index = getIndex(collection, "a_1");
+    assertEquals(1, index.size());
+  }
+
+  // Creating an index before inserting into a collection must add records only if necessary
+  @Test
+  public void testCreateIndexBefore() throws Exception {
+    DBCollection collection = FongoTest.newCollection();
+    collection.ensureIndex(new BasicDBObject("a", 1));
+    collection.insert(new BasicDBObject("_id", 1).append("a", 1));
+    collection.insert(new BasicDBObject("_id", 2));
+
+    Index index = getIndex(collection, "a_1");
+    assertEquals(1, index.size());
   }
 
   private Index getIndex(DBCollection collection, String name) {


### PR DESCRIPTION
Add errors when creating index like : 

``` javascript
> db.fongo.ensureIndex({a:{n:1}});
{
    "err" : "bad index key pattern { a: { n: 1.0 } }",
    "code" : 10098,
    "n" : 0,
    "connectionId" : 256,
    "ok" : 1
}
```
