### PR TITLE
Handling the way filters deal with empty lists

### DIFF
--- a/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
+++ b/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
@@ -459,10 +459,10 @@ public class ExpressionParser {
         } else {
           for (Object storedValue : storedOption) {
             if (storedValue instanceof List) {
-              if (((List) storedValue).isEmpty()) {
-                  if(expression instanceof List){
-                      return ((List) expression).isEmpty();
-                  }
+              if(expression instanceof List){
+                if(storedValue.equals(expression)){
+                  return true;
+                }
               }
               if (((List) storedValue).contains(expression)) {
                 return true;

--- a/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
+++ b/src/main/java/com/foursquare/fongo/impl/ExpressionParser.java
@@ -459,6 +459,11 @@ public class ExpressionParser {
         } else {
           for (Object storedValue : storedOption) {
             if (storedValue instanceof List) {
+              if (((List) storedValue).isEmpty()) {
+                  if(expression instanceof List){
+                      return ((List) expression).isEmpty();
+                  }
+              }
               if (((List) storedValue).contains(expression)) {
                 return true;
               }

--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -684,21 +684,20 @@ public class ExpressionParserTest {
     assertEquals(Arrays.<DBObject>asList(rec1), results);
   }
 
-
   @Test
-  public void testEmptyListsMatch(){
-    DBObject query = new BasicDBObject("a", asList());
+  public void testListsMatch(){
+    DBObject query = new BasicDBObject("a", asList(1,2,3));
     List<DBObject> results = doFilter(
         query,
         new BasicDBObject("a", asList()),
         new BasicDBObject("b", asList()),
-        new BasicDBObject("a", asList("1")),
-        new BasicDBObject("a", asDbList("1")),
+        new BasicDBObject("a", asList(1,2,3)),
+        new BasicDBObject("a", asDbList(1,2,3)),
         new BasicDBObject("a", asDbList())
         );
     assertEquals(Arrays.<DBObject>asList(
-        new BasicDBObject("a", asList()),
-        new BasicDBObject("a", asDbList())
+        new BasicDBObject("a", asList(1,2,3)),
+        new BasicDBObject("a", asDbList(1,2,3))
     ), results);
   }
 

--- a/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
+++ b/src/test/java/com/foursquare/fongo/impl/ExpressionParserTest.java
@@ -398,7 +398,7 @@ public class ExpressionParserTest {
         new BasicDBObject("a", asList(new BasicDBObject("b",1).append("c", 1)))
     ), results);
   }
-  
+
   @Test
   public void testEmbeddedEmptyMatch(){
     DBObject query = new BasicDBObject("a.b.c", 1);
@@ -682,6 +682,24 @@ public class ExpressionParserTest {
         new BasicDBObject("a", asList(new DBRef(null, "c", 2))));
     
     assertEquals(Arrays.<DBObject>asList(rec1), results);
+  }
+
+
+  @Test
+  public void testEmptyListsMatch(){
+    DBObject query = new BasicDBObject("a", asList());
+    List<DBObject> results = doFilter(
+        query,
+        new BasicDBObject("a", asList()),
+        new BasicDBObject("b", asList()),
+        new BasicDBObject("a", asList("1")),
+        new BasicDBObject("a", asDbList("1")),
+        new BasicDBObject("a", asDbList())
+        );
+    assertEquals(Arrays.<DBObject>asList(
+        new BasicDBObject("a", asList()),
+        new BasicDBObject("a", asDbList())
+    ), results);
   }
 
   private void assertQuery(BasicDBObject query, List<DBObject> expected) {

--- a/src/test/java/com/mongodb/FongoDBCollectionTest.java
+++ b/src/test/java/com/mongodb/FongoDBCollectionTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
+import com.sun.corba.se.impl.orb.ParserTable;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -96,4 +97,23 @@ public class FongoDBCollectionTest {
       new BasicDBObject()
     ), results);
   }
+
+  @Test
+  public void applyFindOneProjection(){
+    BasicDBObject existing = new BasicDBObject()
+          .append("_id", 1)
+          .append("aList",asDbList("a","b","c") );
+    collection.insert(existing);
+    DBObject result = collection.findOne(existing);
+    assertEquals("should have projected result",
+        existing,
+        result);
+  }
+
+  BasicDBList asDbList(Object ... objects) {
+     BasicDBList list = new BasicDBList();
+     list.addAll(Arrays.asList(objects));
+     return list;
+  }
+
 }

--- a/src/test/java/com/mongodb/FongoDBCollectionTest.java
+++ b/src/test/java/com/mongodb/FongoDBCollectionTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.Arrays;
 import java.util.List;
 
-import com.sun.corba.se.impl.orb.ParserTable;
 import org.junit.Before;
 import org.junit.Test;
 


### PR DESCRIPTION
Filters assumed lists to always contain elements, the case
of empty lists was not handled correctly. Now we check for
empty lists in stored and expected values when applying the
filter.

Having this data:

``` json
{ "_id" : 1 , "title" : "The Hobbit" , "numberOfPages" : 293 , "characters" : [ ]}
```

A findOne(obj) would not find the document in Fongo, but does
find it in the real mongo.
