### PR TITLE
Multiple projection with same prefix: last projection is the only that survives

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -462,7 +462,10 @@ public class FongoDBCollection extends DBCollection {
 
     if (path.size() > startIndex + 1) {
       if (value instanceof DBObject && !(value instanceof List)){
-        BasicDBObject nb = new BasicDBObject();
+        BasicDBObject nb = (BasicDBObject) ret.get(subKey);
+        if(nb == null) {
+            nb = new BasicDBObject();
+        }
         ret.append(subKey, nb);
         addValuesAtPath(nb, (DBObject) value, path, startIndex + 1);
       } else if (value instanceof List) {

--- a/src/test/java/com/mongodb/FongoDBCollectionTest.java
+++ b/src/test/java/com/mongodb/FongoDBCollectionTest.java
@@ -26,6 +26,33 @@ public class FongoDBCollectionTest {
 
     assertEquals("applied", expected, actual);
   }
+  
+  /** Tests multiprojections that are nested with the same prefix: a.b.c and a.b.d */
+  @Test
+  public void applyNestedProjectionsInclusionsOnly() {
+      final DBObject obj = new BasicDBObjectBuilder()
+          .add("_id", "_id")
+          .add("foo", 123)
+          .push("a")
+              .push("b")
+                  .append("c", 50)
+                  .append("d", 1000)
+                  .append("bar", 1000)
+      .get();
+    
+    final DBObject actual = collection.applyProjections(obj, new BasicDBObject().append("a.b.c", 1)
+                                                                                 .append("a.b.d", 1));
+    final DBObject expected =  new BasicDBObjectBuilder()
+                        .add("_id", "_id")
+                        .push("a")
+                            .push("b")
+                                .append("c", 50)
+                                .append("d", 1000)
+                           .get();
+            
+    assertEquals("applied", expected, actual);
+  }
+  
 
   @Test
   public void applyProjectionsInclusionsWithoutId() {


### PR DESCRIPTION
When asking multiples projections that had the same prefixes (eg: ["a.b.c", "a.b.d"]) only the last projection survive (in this case "a.b.d").

This is not the expected behaviour in mongo.

The solution is try to reuse the the result values.

Test provided.
