### PR TITLE
Work with projection with boolean value.

### DIFF
--- a/src/main/java/com/mongodb/FongoDBCollection.java
+++ b/src/main/java/com/mongodb/FongoDBCollection.java
@@ -493,7 +493,19 @@ public class FongoDBCollection extends DBCollection {
     boolean wasIdExcluded = false;
     List<Tuple2<List<String>,Boolean>> projections = new ArrayList<Tuple2<List<String>, Boolean>>();
     for (String projectionKey : projectionObject.keySet()) {
-      boolean included = ((Number) projectionObject.get(projectionKey)).intValue() > 0;
+      final Object projectionValue = projectionObject.get(projectionKey);
+      final boolean included;
+      if (projectionValue instanceof Number) {
+          included = ((Number) projectionValue).intValue() > 0;
+      } else if (projectionValue instanceof Boolean) {
+          included = ((Boolean)projectionValue).booleanValue();
+      } else {
+          final String msg = "Projection `" + projectionKey 
+             + "' has a value that Fongo doesn't know how to handle: " + projectionValue
+             + " (" + (projectionValue == null ? " " : projectionValue.getClass() + ")");
+          
+          throw new IllegalArgumentException(msg);
+      }
       List<String> projectionPath = Util.split(projectionKey);
       
       if (!ID_KEY.equals(projectionKey)) {

--- a/src/test/java/com/mongodb/FongoDBCollectionTest.java
+++ b/src/test/java/com/mongodb/FongoDBCollectionTest.java
@@ -111,4 +111,25 @@ public class FongoDBCollectionTest {
      return list;
   }
 
+  /** Tests multiprojections that are nested with the same prefix: a.b.c and a.b.d */
+  @Test
+  public void applyProjectionsWithBooleanValues() {
+     final DBObject obj = new BasicDBObjectBuilder()
+          .add("_id", "_id")
+          .add("foo", "oof")
+          .add("bar", "rab")
+          .add("gone", "fishing")
+      .get();
+    
+    final DBObject actual = collection.applyProjections(obj, new BasicDBObject().append("foo", true)
+                                                                                 .append("bar", 1));
+    final DBObject expected =  new BasicDBObjectBuilder()
+                        .add("_id", "_id")
+                        .add("foo", "oof")
+                        .add("bar", "rab")
+                        .get();
+            
+    assertEquals("applied", expected, actual);
+  }
+
 }


### PR DESCRIPTION
Before this change only numeric projections ({foo: 1} were accepted, while
boolean projection are valid ({foo: true}.

In particular Morphia (https://code.google.com/p/morphia/)
Query#retrievedFields creates a projection using booleans.

Test included.
